### PR TITLE
Remove Dependency on Fraser's casper-node fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,8 +313,8 @@ dependencies = [
 
 [[package]]
 name = "casper-execution-engine"
-version = "1.5.0"
-source = "git+https://github.com/Fraser999/casper-node?branch=testing-feature#a7c89280ebdffa6f6ac07788851103b2ab3a2791"
+version = "2.0.0"
+source = "git+https://github.com/casper-network/casper-node?branch=dev#e01b528db64f96fc1d3eac8b3b8e58e1337b398d"
 dependencies = [
  "anyhow",
  "base16",
@@ -355,7 +355,7 @@ dependencies = [
 [[package]]
 name = "casper-hashing"
 version = "1.4.3"
-source = "git+https://github.com/Fraser999/casper-node?branch=testing-feature#a7c89280ebdffa6f6ac07788851103b2ab3a2791"
+source = "git+https://github.com/casper-network/casper-node?branch=dev#e01b528db64f96fc1d3eac8b3b8e58e1337b398d"
 dependencies = [
  "base16",
  "blake2",
@@ -373,11 +373,12 @@ dependencies = [
 [[package]]
 name = "casper-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/Fraser999/casper-node?branch=testing-feature#a7c89280ebdffa6f6ac07788851103b2ab3a2791"
+source = "git+https://github.com/casper-network/casper-node?branch=dev#e01b528db64f96fc1d3eac8b3b8e58e1337b398d"
 dependencies = [
  "bytes",
  "futures",
  "http",
+ "itertools",
  "serde",
  "serde_json",
  "tracing",
@@ -386,8 +387,8 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.5"
-source = "git+https://github.com/Fraser999/casper-node?branch=testing-feature#a7c89280ebdffa6f6ac07788851103b2ab3a2791"
+version = "1.4.6"
+source = "git+https://github.com/casper-network/casper-node?branch=dev#e01b528db64f96fc1d3eac8b3b8e58e1337b398d"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -472,7 +473,7 @@ dependencies = [
 [[package]]
 name = "casper-node-macros"
 version = "1.4.3"
-source = "git+https://github.com/Fraser999/casper-node?branch=testing-feature#a7c89280ebdffa6f6ac07788851103b2ab3a2791"
+source = "git+https://github.com/casper-network/casper-node?branch=dev#e01b528db64f96fc1d3eac8b3b8e58e1337b398d"
 dependencies = [
  "Inflector",
  "indexmap",
@@ -484,7 +485,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "1.5.0"
-source = "git+https://github.com/Fraser999/casper-node?branch=testing-feature#a7c89280ebdffa6f6ac07788851103b2ab3a2791"
+source = "git+https://github.com/casper-network/casper-node?branch=dev#e01b528db64f96fc1d3eac8b3b8e58e1337b398d"
 dependencies = [
  "base16",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,13 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-#[features]
-#default = ["casper-mainnet"]
-#casper-mainnet = ["casper-node/casper-mainnet"]
-
 # todo Remove unused dependencies
 [dependencies]
 anyhow = {version = "1.0.44", default-features = false }
-casper-node = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature"}
-casper-types = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature"}
-casper-hashing = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature"}
-casper-execution-engine = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature"}
+casper-node = { git = "https://github.com/casper-network/casper-node", branch = "dev"}
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev"}
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev"}
+casper-execution-engine = { git = "https://github.com/casper-network/casper-node", branch = "dev"}
 derive_more = "0.99.7"
 futures = "0.3.17"
 hex = "0.4.3"
@@ -43,12 +39,12 @@ warp = { version = "0.3.0", features = ["compression"] }
 wheelbuf = "0.2.0"
 
 [patch.crates-io]
-casper-execution-engine = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature" }
-casper-node = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature" }
-casper-hashing = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature" }
-casper-types = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature" }
+casper-execution-engine = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-node = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-hashing = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev" }
 
 [dev-dependencies]
-casper-node = { git = "https://github.com/Fraser999/casper-node", branch = "testing-feature", features = ["testing"]}
+casper-node = { git = "https://github.com/casper-network/casper-node", branch = "dev", features = ["testing"]}
 pretty_assertions = "0.7.2"
 reqwest = { version = "0.11.3", features = ["stream"] }


### PR DESCRIPTION
See the title. The feature that Fraser mocked up on his own fork has now been merged into the main casper-node repo so we can target that instead of his fork.