### PR TITLE
Remove Filter Priority

### DIFF
--- a/EXAMPLE_CONFIG.toml
+++ b/EXAMPLE_CONFIG.toml
@@ -5,10 +5,6 @@
     delay_between_retries_in_seconds = 5
     allow_partial_connection = false
     enable_logging = true
-    # if filter_priority is not provided a default setting is used (lower number is higher priority):
-    #   main = 0
-    #   sigs = 1
-    #   deploys = 2
 
 [[connections]]
     ip_address = "127.0.0.1"
@@ -17,10 +13,6 @@
     delay_between_retries_in_seconds = 5
     allow_partial_connection = false
     enable_logging = false
-    [connections.filter_priority]
-        main = 1
-        sigs = 0
-        deploys = 2
 
 [[connections]]
     ip_address = "127.0.0.1"
@@ -29,11 +21,6 @@
     delay_between_retries_in_seconds = 5
     allow_partial_connection = false
     enable_logging = false
-    # Since the below is the same as the default it could be omitted
-    [connections.filter_priority]
-        main = 0
-        sigs = 1
-        deploys = 2
 
 [storage]
 storage_path = "./target/storage"

--- a/sidecar/src/main.rs
+++ b/sidecar/src/main.rs
@@ -59,7 +59,6 @@ async fn run(config: Config) -> Result<(), Error> {
             connection.max_retries,
             connection.delay_between_retries_in_seconds,
             connection.allow_partial_connection,
-            connection.filter_priority.clone(),
         )
         .await?;
         event_listeners.push(event_listener);

--- a/sidecar/src/testing/testing_config.rs
+++ b/sidecar/src/testing/testing_config.rs
@@ -1,7 +1,6 @@
-use casper_event_listener::FilterPriority;
 use tempfile::TempDir;
 
-use crate::types::config::Config;
+use crate::types::config::{Config, Connection};
 
 /// A basic wrapper with helper methods for constructing and tweaking [Config]s for use in tests.
 pub(crate) struct TestingConfig {
@@ -14,15 +13,13 @@ pub(crate) struct TestingConfig {
 /// - The outbound server (REST & SSE) ports are set dynamically to free ports.
 #[cfg(test)]
 pub(crate) fn prepare_config(temp_storage: &TempDir) -> TestingConfig {
-    let path_to_temp_storage = temp_storage
-        .path()
-        .to_str()
-        .expect("Error getting path of temporary directory")
-        .to_string();
+    let path_to_temp_storage = temp_storage.path().to_string_lossy().to_string();
 
-    TestingConfig::default()
-        .set_storage_path(path_to_temp_storage)
-        .allocate_available_ports()
+    let mut testing_config = TestingConfig::default();
+    testing_config.set_storage_path(path_to_temp_storage);
+    testing_config.allocate_available_ports();
+
+    testing_config
 }
 
 impl TestingConfig {
@@ -35,61 +32,66 @@ impl TestingConfig {
 
     /// Specify where test storage (database, sse cache) should be located.
     /// By default it is set to `/target/test_storage` however it is recommended to overwrite this with a `TempDir` path for testing purposes.
-    pub(crate) fn set_storage_path(mut self, path: String) -> Self {
+    pub(crate) fn set_storage_path(&mut self, path: String) {
         self.config.storage.storage_path = path;
-        self
     }
 
-    /// Specify the port that the sidecar should connect to.
-    /// By default it is set to `18101` - the SSE port of a node in the default NCTL network.
-    pub(crate) fn set_connection_address(mut self, ip_address: Option<String>, port: u16) -> Self {
-        if let Some(address) = ip_address {
-            self.config.connections[0].ip_address = address;
-        }
-        self.config.connections[0].sse_port = port;
-        self
+    pub(crate) fn add_connection(&mut self, ip_address: Option<String>, port: Option<u16>) -> u16 {
+        let random_port = portpicker::pick_unused_port().unwrap();
+        let connection = Connection {
+            ip_address: ip_address.unwrap_or("127.0.0.1".to_string()),
+            sse_port: port.unwrap_or(random_port),
+            max_retries: 0,
+            delay_between_retries_in_seconds: 0,
+            allow_partial_connection: false,
+            enable_logging: false,
+        };
+        self.config.connections.push(connection);
+        random_port
     }
 
     /// Set how the sidecar should handle the case where it is only able to connect to one or two of the node's filters.
-    pub(crate) fn set_allow_partial_connection(mut self, allow_partial_connection: bool) -> Self {
-        self.config.connections[0].allow_partial_connection = allow_partial_connection;
-        self
-    }
-
-    pub(crate) fn set_filter_priority(&mut self, filter_priority: FilterPriority) {
-        self.config.connections[0].filter_priority = filter_priority;
+    pub(crate) fn set_allow_partial_connection_for_node(
+        &mut self,
+        port_of_node: u16,
+        allow_partial_connection: bool,
+    ) {
+        for mut connection in &mut self.config.connections {
+            if connection.sse_port == port_of_node {
+                connection.allow_partial_connection = allow_partial_connection;
+                break;
+            }
+        }
     }
 
     /// Specify the retry configuration settings. By default they are set as follows:
     /// - `max_retries`: 3
     /// - `delay_between_retries_in_seconds`: 5
-    pub(crate) fn configure_retry_settings(
-        mut self,
+    pub(crate) fn set_retries_for_node(
+        &mut self,
+        port_of_node: u16,
         max_retries: u8,
         delay_between_retries_in_seconds: u8,
-    ) -> Self {
-        for connection in &mut self.config.connections {
-            connection.max_retries = max_retries;
-            connection.delay_between_retries_in_seconds = delay_between_retries_in_seconds;
+    ) {
+        for mut connection in &mut self.config.connections {
+            if connection.sse_port == port_of_node {
+                connection.max_retries = max_retries;
+                connection.delay_between_retries_in_seconds = delay_between_retries_in_seconds;
+                break;
+            }
         }
-        self
     }
 
     /// Dynamically allocates free ports for:
-    /// - Node Connection
     /// - REST Server
     /// - Event Stream Server  
     ///
     /// Updates the ports in the config accordingly.
-    pub(crate) fn allocate_available_ports(mut self) -> Self {
-        let node_connection_port = portpicker::pick_unused_port().expect("Error getting free port");
+    pub(crate) fn allocate_available_ports(&mut self) {
         let rest_server_port = portpicker::pick_unused_port().expect("Error getting free port");
         let sse_server_port = portpicker::pick_unused_port().expect("Error getting free port");
         self.config.rest_server.port = rest_server_port;
         self.config.event_stream_server.port = sse_server_port;
-        self.config.connections[0].sse_port = node_connection_port;
-
-        self
     }
 
     /// Returns the inner [Config]
@@ -98,8 +100,12 @@ impl TestingConfig {
     }
 
     /// Returns the port that the sidecar is configured to connect to, i.e. the Fake Event Stream port.
-    pub(crate) fn connection_port(&self) -> u16 {
-        self.config.connections[0].sse_port
+    pub(crate) fn connection_ports(&self) -> Vec<u16> {
+        self.config
+            .connections
+            .iter()
+            .map(|conn| conn.sse_port)
+            .collect::<Vec<u16>>()
     }
 
     /// Returns the port that the sidecar REST server is bound to.

--- a/sidecar/src/types/config.rs
+++ b/sidecar/src/types/config.rs
@@ -1,8 +1,6 @@
 use anyhow::{Context, Error};
 use serde::Deserialize;
 
-use casper_event_listener::FilterPriority;
-
 pub fn read_config(config_path: &str) -> Result<Config, Error> {
     let toml_content =
         std::fs::read_to_string(config_path).context("Error reading config file contents")?;
@@ -27,8 +25,6 @@ pub struct Connection {
     pub delay_between_retries_in_seconds: u8,
     pub allow_partial_connection: bool,
     pub enable_logging: bool,
-    #[serde(default)]
-    pub filter_priority: FilterPriority,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -61,7 +57,6 @@ pub struct EventStreamServerConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use casper_event_listener::FilterPriority;
 
     #[test]
     fn should_parse_config_toml() {
@@ -74,7 +69,6 @@ mod tests {
                     delay_between_retries_in_seconds: 5,
                     allow_partial_connection: false,
                     enable_logging: true,
-                    filter_priority: FilterPriority::default(),
                 },
                 Connection {
                     ip_address: "127.0.0.1".to_string(),
@@ -83,7 +77,6 @@ mod tests {
                     delay_between_retries_in_seconds: 5,
                     allow_partial_connection: false,
                     enable_logging: false,
-                    filter_priority: FilterPriority::new(1, 0, 2).unwrap(),
                 },
                 Connection {
                     ip_address: "127.0.0.1".to_string(),
@@ -92,7 +85,6 @@ mod tests {
                     delay_between_retries_in_seconds: 5,
                     allow_partial_connection: false,
                     enable_logging: false,
-                    filter_priority: FilterPriority::default(),
                 },
             ],
             storage: StorageConfig {
@@ -130,7 +122,6 @@ mod tests {
                 max_retries: 3,
                 delay_between_retries_in_seconds: 5,
                 enable_logging: false,
-                filter_priority: FilterPriority::default(),
             }
         }
     }


### PR DESCRIPTION
As the title says.

This PR totally removes any notion of prioritisation with regards to the filtered channels coming off the node.

If there are limited slots on the node's server the sidecar will randomly (as determined by the scheduler) connect to each stream. There is no guarantee which will be connected if there are less than 3 slots available.

The config value, `allow_partial_connection` can be set as follows:
- `false`: the sidecar will ensure all filters are connected before beginning and shutdown if it can't connect to all three filters.
- `true`: the sidecar will start processing SSEs as soon as it connects to any of the filters. It will continue even if it isn't able to get the other(s).