### PR TITLE
Pending deploy aggregations.

### DIFF
--- a/sidecar/src/sql/tables.rs
+++ b/sidecar/src/sql/tables.rs
@@ -9,5 +9,6 @@ pub mod event_type;
 pub mod fault;
 pub mod finality_signature;
 pub mod migration;
+pub mod pending_deploy_aggregations;
 pub mod shutdown;
 pub mod step;

--- a/sidecar/src/sql/tables/pending_deploy_aggregations.rs
+++ b/sidecar/src/sql/tables/pending_deploy_aggregations.rs
@@ -1,0 +1,86 @@
+use sea_query::InsertStatement;
+#[cfg(test)]
+use sea_query::SqliteQueryBuilder;
+use sea_query::{error::Result as SqResult, ColumnDef, Iden, Query, Table, TableCreateStatement};
+
+#[derive(Iden, Clone)]
+pub(super) enum PendingDeployAggregations {
+    #[iden = "PendingDeployAggregations"]
+    Table,
+    Id,
+    DeployHash,
+    BlockHash,
+    BlockTimestamp,
+    CreatedAt,
+}
+
+/// Creates insert statement for a command to assemble aggregate DeployAggregate.
+/// The maybe_block_data is a option tuple of blocks deploy hash and its creation timestamp.
+pub fn create_insert_stmt(
+    deploy_hash: String,
+    maybe_block_data: Option<(String, u64)>,
+) -> SqResult<InsertStatement> {
+    let mut cols = vec![PendingDeployAggregations::DeployHash];
+    let mut vals = vec![deploy_hash.into()];
+    if let Some((block_hash, timestamp)) = maybe_block_data {
+        cols.push(PendingDeployAggregations::BlockHash);
+        cols.push(PendingDeployAggregations::BlockTimestamp);
+        vals.push(block_hash.into());
+        vals.push(timestamp.into());
+    }
+    Ok(Query::insert()
+        .into_table(PendingDeployAggregations::Table)
+        .columns(cols)
+        .values(vals)?
+        .to_owned())
+}
+
+pub fn create_table_stmt() -> TableCreateStatement {
+    Table::create()
+        .table(PendingDeployAggregations::Table)
+        .if_not_exists()
+        .col(
+            ColumnDef::new(PendingDeployAggregations::Id)
+                .big_unsigned()
+                .auto_increment()
+                .not_null()
+                .primary_key(),
+        )
+        .col(
+            ColumnDef::new(PendingDeployAggregations::DeployHash)
+                .not_null()
+                .string(),
+        )
+        .col(ColumnDef::new(PendingDeployAggregations::BlockHash).string())
+        .col(ColumnDef::new(PendingDeployAggregations::BlockTimestamp).integer_len(13))
+        .col(
+            ColumnDef::new(PendingDeployAggregations::CreatedAt)
+                .timestamp()
+                .not_null()
+                // This can be replaced with better syntax when https://github.com/SeaQL/sea-query/pull/428 merges.
+                .extra("DEFAULT CURRENT_TIMESTAMP".to_string()),
+        )
+        .to_owned()
+}
+
+#[test]
+pub fn create_insert_stmt_test() {
+    let sql = create_insert_stmt("abc".to_string(), Some(("block_hash_1".to_string(), 555)))
+        .unwrap()
+        .to_string(SqliteQueryBuilder);
+    assert_eq!(
+        sql,
+        "INSERT INTO \"PendingDeployAggregations\" (\"deploy_hash\", \"block_hash\", \"block_timestamp\") VALUES ('abc', 'block_hash_1', 555)"
+    )
+}
+
+#[test]
+pub fn create_insert_stmt_without_block_data_test() {
+    let sql = create_insert_stmt("abc".to_string(), None)
+        .unwrap()
+        .to_string(SqliteQueryBuilder);
+    assert_eq!(
+        sql,
+        "INSERT INTO \"PendingDeployAggregations\" (\"deploy_hash\") VALUES ('abc')"
+    )
+}

--- a/sidecar/src/sqlite_database.rs
+++ b/sidecar/src/sqlite_database.rs
@@ -104,6 +104,22 @@ impl SqliteDatabase {
         Ok(sqlite_db)
     }
 
+    async fn save_assemble_deploy_aggregate_command<'c>(
+        &self,
+        transaction: &mut Transaction<'c, Sqlite>,
+        deploy_hash: String,
+        maybe_block_data: Option<(String, u64)>,
+    ) -> Result<(), DatabaseWriteError> {
+        let insert_stmt =
+            tables::pending_deploy_aggregations::create_insert_stmt(deploy_hash, maybe_block_data)?
+                .to_string(SqliteQueryBuilder);
+        transaction
+            .execute(insert_stmt.as_str())
+            .await
+            .map(|_| ())
+            .map_err(|err| DatabaseWriteError::Unhandled(Error::from(err)))
+    }
+
     ///This function is temporary. DeployAggregateEntitis should be assembled automatically when
     /// DeployAccepted, DeployProcessed, DeployExpired and/or BlockAdded entities are being observed.
     /// But this functionality will be introduced in the next PR since this one is big enough

--- a/sidecar/src/sqlite_database/tests.rs
+++ b/sidecar/src/sqlite_database/tests.rs
@@ -205,10 +205,12 @@ async fn should_retrieve_deploy_aggregate_of_expired() {
         .await
         .expect("Error saving deploy_expired");
 
-    sqlite_db
+    let aggregate = sqlite_db
         .get_deploy_aggregate_by_hash(&deploy_accepted.hex_encoded_hash())
         .await
         .expect("Error getting deploy aggregate by hash");
+    assert_eq!(aggregate.deploy_hash, deploy_accepted.hex_encoded_hash());
+    assert!(aggregate.block_timestamp.is_none());
 }
 
 #[tokio::test]

--- a/sidecar/src/types/database.rs
+++ b/sidecar/src/types/database.rs
@@ -387,6 +387,9 @@ impl Migration {
                     StatementWrapper::IndexCreateStatement(Box::new(
                         tables::deploy_aggregate::create_deploy_aggregate_is_processed_index(),
                     )),
+                    StatementWrapper::TableCreateStatement(Box::new(
+                        tables::pending_deploy_aggregations::create_table_stmt(),
+                    )),
                 ])
             },
             script_executor: None,

--- a/sidecar/src/types/sse_events.rs
+++ b/sidecar/src/types/sse_events.rs
@@ -30,8 +30,30 @@ pub struct BlockAdded {
     pub block: Box<JsonBlock>,
 }
 
-#[cfg(test)]
 impl BlockAdded {
+    pub fn get_timestamp(&self) -> Timestamp {
+        self.block.header.timestamp
+    }
+
+    pub fn get_all_deploy_hashes(&self) -> Vec<String> {
+        let deploy_hashes = self.block.deploy_hashes();
+        let transfer_hashes = self.block.transfer_hashes();
+        deploy_hashes
+            .iter()
+            .chain(transfer_hashes.iter())
+            .map(|hash_struct| hex::encode(hash_struct.inner()))
+            .collect()
+    }
+
+    pub fn hex_encoded_hash(&self) -> String {
+        hex::encode(self.block_hash.inner())
+    }
+
+    pub fn get_height(&self) -> u64 {
+        self.block.header.height
+    }
+
+    #[cfg(test)]
     pub fn random_with_data(
         rng: &mut TestRng,
         deploy_hashes: Vec<DeployHash>,
@@ -44,27 +66,13 @@ impl BlockAdded {
         }
     }
 
+    #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
         let block = JsonBlock::random(rng);
         Self {
             block_hash: block.hash,
             block: Box::new(block),
         }
-    }
-}
-
-impl BlockAdded {
-    #[cfg(test)]
-    pub fn get_timestamp(&self) -> Timestamp {
-        self.block.header.timestamp
-    }
-
-    pub fn hex_encoded_hash(&self) -> String {
-        hex::encode(self.block_hash.inner())
-    }
-
-    pub fn get_height(&self) -> u64 {
-        self.block.header.height
     }
 }
 


### PR DESCRIPTION
Introduced PendingDeployAggregations table. A single row in that table implies that a rebuild for the PendingDeployAggregation#DeployHash is required. PendingDeployAggregations holds data that is required for the assembly and is not easily available in other tables. For instance PendingDeployAggregations has BlockTimestamp because the blocks timestamp is held inside the `raw` blob of BlockAdded. Pulling out the BlockTimestamp from BlockAdded at the moment of DeployAggregate assembly would be a drag, that's why we hold it in PendingDeployAggregation.