### PR TITLE
Enable server field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
  "casper-event-types",
  "casper-types",
  "colored",
- "derive-new",
+ "derive-new 0.5.9",
  "eventsource-stream",
  "futures",
  "futures-util",
@@ -641,7 +641,6 @@ dependencies = [
  "base16",
  "bincode",
  "bytes",
- "casper-event-types",
  "casper-json-rpc",
  "casper-types",
  "datasize",
@@ -675,11 +674,14 @@ name = "casper-sidecar"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "backtrace",
  "casper-event-sidecar",
+ "casper-event-types",
  "casper-rpc-sidecar",
  "clap 4.5.2",
  "datasize",
+ "derive-new 0.6.0",
  "futures",
  "num_cpus",
  "serde",
@@ -1059,6 +1061,17 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ members = [
 [workspace.dependencies]
 anyhow = "1"
 async-stream = "0.3.4"
+async-trait = "0.1.77"
 casper-types = { git = "https://github.com/casper-network/casper-node", branch="feat-2.0" }
 casper-event-sidecar = { path = "./event_sidecar", version = "1.0.0" }
+casper-event-types = { path = "./types", version = "1.0.0" }
 casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }
 datasize = "0.2.11"
 futures = "0"

--- a/event_sidecar/Cargo.toml
+++ b/event_sidecar/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { workspace = true }
 async-trait = "0.1.56"
 bytes = "1.2.0"
 casper-event-listener = { path = "../listener", version = "1.0.0" }
-casper-event-types = { path = "../types", version = "1.0.0" }
+casper-event-types.workspace = true
 casper-types = { workspace = true, features = ["std", "json-schema"] }
 derive-new = "0.5.9"
 eventsource-stream = "0.2.3"
@@ -54,7 +54,7 @@ wheelbuf = "0.2.0"
 
 [dev-dependencies]
 async-stream = { workspace = true }
-casper-event-types = { path = "../types", version = "1.0.0", features = ["sse-data-testing"] }
+casper-event-types = { workspace = true, features = ["sse-data-testing"] }
 casper-types = { workspace = true, features = ["std", "testing"] }
 colored = "2.0.0"
 futures-util = { workspace = true }

--- a/event_sidecar/src/database/migration_manager/tests.rs
+++ b/event_sidecar/src/database/migration_manager/tests.rs
@@ -13,7 +13,6 @@ const MAX_CONNECTIONS: u32 = 100;
 #[tokio::test]
 async fn should_have_version_none_if_no_migrations_applied() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res = MigrationManager::apply_migrations(sqlite_db.clone(), vec![]).await;
@@ -27,7 +26,6 @@ async fn should_have_version_none_if_no_migrations_applied() {
 #[tokio::test]
 async fn should_store_failed_version_if_migration_was_erroneous() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res =
@@ -43,7 +41,6 @@ async fn should_store_failed_version_if_migration_was_erroneous() {
 #[tokio::test]
 async fn should_apply_migration() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res =
@@ -66,7 +63,6 @@ async fn should_apply_migration() {
 #[tokio::test]
 async fn should_apply_migrations() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res = MigrationManager::apply_migrations(
@@ -104,7 +100,6 @@ async fn should_apply_migrations() {
 async fn given_ok_and_failing_migrations_first_should_be_applied_second_only_stored_in_migrations_table(
 ) {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res = MigrationManager::apply_migrations(
@@ -123,7 +118,6 @@ async fn given_ok_and_failing_migrations_first_should_be_applied_second_only_sto
 #[tokio::test]
 async fn should_fail_if_migration_has_no_version() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
     let migration = build_no_version_migration();
 
@@ -135,7 +129,6 @@ async fn should_fail_if_migration_has_no_version() {
 #[tokio::test]
 async fn should_fail_if_two_migrations_have_the_same_version() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res = MigrationManager::apply_migrations(
@@ -150,7 +143,6 @@ async fn should_fail_if_two_migrations_have_the_same_version() {
 #[tokio::test]
 async fn given_shuffled_migrations_should_sort_by_version() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res = MigrationManager::apply_migrations(
@@ -179,7 +171,6 @@ async fn given_shuffled_migrations_should_sort_by_version() {
 #[tokio::test]
 async fn should_execute_script() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res =
@@ -203,7 +194,6 @@ async fn should_execute_script() {
 #[tokio::test]
 async fn given_failed_migration_should_not_execute_next_migration_() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res = MigrationManager::apply_migrations(
@@ -222,7 +212,6 @@ async fn given_failed_migration_should_not_execute_next_migration_() {
 #[tokio::test]
 async fn should_store_failed_version_if_script_fails() {
     let sqlite_db = SqliteDatabase::new_in_memory_no_migrations(MAX_CONNECTIONS)
-        .await
         .expect("Error opening database in memory");
 
     let apply_res = MigrationManager::apply_migrations(

--- a/event_sidecar/src/lib.rs
+++ b/event_sidecar/src/lib.rs
@@ -83,7 +83,7 @@ pub async fn run(
 
     let event_broadcasting_handle =
         start_event_broadcasting(&config, storage_path, outbound_sse_data_receiver);
-
+    info!(address = %config.event_stream_server.port, "started {} server", "SSE");
     tokio::try_join!(
         flatten_handle(event_broadcasting_handle),
         flatten_handle(listening_task_handle),

--- a/event_sidecar/src/rest_server.rs
+++ b/event_sidecar/src/rest_server.rs
@@ -13,6 +13,7 @@ use metrics::rest_api::observe_path_abstraction_time;
 use std::time::Duration;
 use std::{net::TcpListener, time::Instant};
 use tower::{buffer::Buffer, make::Shared, ServiceBuilder};
+use tracing::info;
 use warp::Filter;
 
 use crate::{
@@ -43,7 +44,7 @@ pub async fn run_server<Db: DatabaseReader + Clone + Send + Sync + 'static>(
         )
         .layer(MetricsLayer::new(path_abstraction_for_metrics))
         .service(warp_service);
-
+    info!(address = %address, "started {} server", "REST API");
     Server::from_tcp(listener)?
         .serve(Shared::new(Buffer::new(tower_service, 50)))
         .await?;

--- a/event_sidecar/src/types/config.rs
+++ b/event_sidecar/src/types/config.rs
@@ -25,6 +25,7 @@ pub(crate) const DEFAULT_POSTGRES_STORAGE_PATH: &str =
 // This struct is used to parse the toml-formatted config file so the values can be utilised in the code.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct SseEventServerConfig {
+    pub enable_server: bool,
     pub inbound_channel_size: Option<usize>,
     pub outbound_channel_size: Option<usize>,
     pub connections: Vec<Connection>,
@@ -35,6 +36,7 @@ pub struct SseEventServerConfig {
 impl Default for SseEventServerConfig {
     fn default() -> Self {
         Self {
+            enable_server: true,
             inbound_channel_size: Some(100),
             outbound_channel_size: Some(100),
             connections: vec![],
@@ -224,6 +226,7 @@ impl TryFrom<PostgresqlConfigSerdeTarget> for PostgresqlConfig {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct RestApiServerConfig {
+    pub enable_server: bool,
     pub port: u16,
     pub max_concurrent_requests: u32,
     pub max_requests_per_second: u32,
@@ -238,9 +241,22 @@ pub struct EventStreamServerConfig {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct AdminApiServerConfig {
+    pub enable_server: bool,
     pub port: u16,
     pub max_concurrent_requests: u32,
     pub max_requests_per_second: u32,
+}
+
+#[cfg(any(feature = "testing", test))]
+impl Default for AdminApiServerConfig {
+    fn default() -> Self {
+        Self {
+            enable_server: true,
+            port: 1211,
+            max_concurrent_requests: 50,
+            max_requests_per_second: 60,
+        }
+    }
 }
 
 #[cfg(any(feature = "testing", test))]
@@ -333,6 +349,7 @@ mod tests {
     impl Default for RestApiServerConfig {
         fn default() -> Self {
             Self {
+                enable_server: true,
                 port: 17777,
                 max_concurrent_requests: 50,
                 max_requests_per_second: 50,

--- a/event_sidecar/src/types/database.rs
+++ b/event_sidecar/src/types/database.rs
@@ -75,6 +75,12 @@ impl Database {
             }
         }
     }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn for_tests() -> Database {
+        let sqlite_database = SqliteDatabase::new_in_memory_no_migrations(100).unwrap();
+        Database::SqliteDatabaseWrapper(sqlite_database)
+    }
 }
 
 /// Describes a reference for the writing interface of an 'Event Store' database.

--- a/listener/Cargo.toml
+++ b/listener/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/casper-network/casper-sidecar/"
 [dependencies]
 anyhow = { workspace = true }
 async-stream = { workspace = true }
-async-trait = "0.1.72"
+async-trait = { workspace = true }
 bytes = "1.2.0"
-casper-event-types = { path = "../types", version = "1.0.0" }
+casper-event-types.workspace = true
 casper-types = { workspace = true, features = ["std"] }
 eventsource-stream = "0.2.3"
 futures = { workspace = true }
@@ -31,7 +31,7 @@ tracing = { workspace = true, default-features = true }
 url = "2.3.1"
 
 [dev-dependencies]
-casper-event-types = { path = "../types", version = "1.0.0", features = ["sse-data-testing"] }
+casper-event-types = { workspace = true, features = ["sse-data-testing"] }
 eventsource-stream = "0.2.3"
 mockito = "1.2.0"
 portpicker = "0.1.1"

--- a/rpc_sidecar/Cargo.toml
+++ b/rpc_sidecar/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1.50"
 backtrace = "0.3.50"
 base16 = "0.2.1"
 bincode = "1"
-casper-event-types = { path = "../types", version = "1.0.0" }
+bytes = "1.5.0"
 casper-json-rpc = { version = "1.0.0", path = "../json_rpc" }
 casper-types = { workspace = true, features = ["datasize", "json-schema", "std"] }
 datasize = { workspace = true, features = ["detailed", "fake_clock-types"] }
@@ -26,6 +26,7 @@ hyper = "0.14.26"
 juliet = { version ="0.2", features = ["tracing"] }
 num_cpus = "1"
 once_cell.workspace = true
+portpicker = "0.1.1"
 rand = "0.8.3"
 schemars = { version = "0.8.16", features = ["preserve_order", "impl_json_schema"] }
 serde = { workspace = true, default-features = true, features = ["derive"] }
@@ -41,9 +42,7 @@ warp = { version = "0.3.6", features = ["compression"] }
 
 [dev-dependencies]
 assert-json-diff = "2"
-bytes = "1.5.0"
 casper-types = { workspace = true, features = ["datasize", "json-schema", "std", "testing"] }
-portpicker = "0.1.1"
 pretty_assertions = "0.7.2"
 regex = "1"
 tempfile = "3"

--- a/rpc_sidecar/src/config.rs
+++ b/rpc_sidecar/src/config.rs
@@ -155,7 +155,7 @@ impl NodeClientConfig {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(feature = "testing", test))]
     pub fn finite_retries_config(port: u16, num_of_retries: usize) -> Self {
         let local_socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
         NodeClientConfig {

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 anyhow = { workspace = true }
 backtrace = "0.3.69"
 casper-event-sidecar = { workspace = true }
+casper-event-types = { workspace = true }
 casper-rpc-sidecar = { workspace = true }
 clap = { version = "4.0.32", features = ["derive"] }
 datasize = { workspace = true, features = ["detailed", "fake_clock-types"] }
@@ -24,6 +25,8 @@ toml = { workspace = true }
 tracing = { workspace = true, default-features = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json"] }
 thiserror = { workspace = true }
+derive-new = "0.6.0"
+async-trait = { workspace = true }
 
 [dev-dependencies]
 casper-event-sidecar = { workspace = true, features = ["testing"] }

--- a/sidecar/src/component.rs
+++ b/sidecar/src/component.rs
@@ -1,0 +1,408 @@
+use anyhow::Error;
+use async_trait::async_trait;
+use casper_event_sidecar::{run as run_sse_sidecar, run_admin_server, run_rest_server, Database};
+use casper_rpc_sidecar::build_rpc_server;
+use derive_new::new;
+use futures::{future::BoxFuture, FutureExt};
+use std::{
+    fmt::{Display, Formatter, Result as FmtResult},
+    process::ExitCode,
+};
+use tracing::info;
+
+use crate::config::SidecarConfig;
+
+#[derive(Debug)]
+pub enum ComponentError {
+    Initialization {
+        component_name: String,
+        internal_error: Error,
+    },
+    Runtime {
+        component_name: String,
+        internal_error: Error,
+    },
+}
+
+impl ComponentError {
+    pub fn runtime_error(component_name: String, error: Error) -> Self {
+        ComponentError::Runtime {
+            component_name,
+            internal_error: error,
+        }
+    }
+
+    pub fn initialization_error(component_name: String, error: Error) -> Self {
+        ComponentError::Initialization {
+            component_name,
+            internal_error: error,
+        }
+    }
+}
+
+impl Display for ComponentError {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self {
+            ComponentError::Initialization {
+                component_name,
+                internal_error,
+            } => write!(
+                f,
+                "Error initializing component '{}': {}",
+                component_name, internal_error
+            ),
+            ComponentError::Runtime {
+                component_name,
+                internal_error,
+            } => write!(
+                f,
+                "Error running component '{}': {}",
+                component_name, internal_error
+            ),
+        }
+    }
+}
+
+/// Abstraction for an individual component of sidecar. The assumption is that this should be
+/// a long running task that is spawned into the tokio runtime.
+#[async_trait]
+pub trait Component {
+    fn name(&self) -> String;
+    /// Returns a future that represents the task of the running component.
+    /// If the return value is Ok(None) it means that the component is disabled (or not configured at all) and should not run.
+    async fn prepare_component_task(
+        &self,
+        config: &SidecarConfig,
+    ) -> Result<Option<BoxFuture<'_, Result<ExitCode, ComponentError>>>, ComponentError>;
+}
+
+#[derive(new)]
+pub struct SseServerComponent {
+    maybe_database: Option<Database>,
+}
+
+#[async_trait]
+impl Component for SseServerComponent {
+    async fn prepare_component_task(
+        &self,
+        config: &SidecarConfig,
+    ) -> Result<Option<BoxFuture<'_, Result<ExitCode, ComponentError>>>, ComponentError> {
+        if let (Some(storage_config), Some(database), Some(sse_server_config)) =
+            (&config.storage, &self.maybe_database, &config.sse_server)
+        {
+            if sse_server_config.enable_server {
+                // If sse server is configured, both storage config and database must be "Some" here. This should be ensured by prior validation.
+                let future = run_sse_sidecar(
+                    sse_server_config.clone(),
+                    database.clone(),
+                    storage_config.get_storage_path(),
+                )
+                .map(|res| res.map_err(|e| ComponentError::runtime_error(self.name(), e)));
+                Ok(Some(Box::pin(future)))
+            } else {
+                info!("SSE server is disabled. Skipping...");
+                Ok(None)
+            }
+        } else {
+            info!("SSE server not configured. Skipping");
+            Ok(None)
+        }
+    }
+
+    fn name(&self) -> String {
+        "sse_event_server".to_string()
+    }
+}
+
+#[derive(new)]
+pub struct RestApiComponent {
+    maybe_database: Option<Database>,
+}
+
+#[async_trait]
+impl Component for RestApiComponent {
+    async fn prepare_component_task(
+        &self,
+        config: &SidecarConfig,
+    ) -> Result<Option<BoxFuture<'_, Result<ExitCode, ComponentError>>>, ComponentError> {
+        if let (Some(config), Some(database)) = (&config.rest_api_server, &self.maybe_database) {
+            if config.enable_server {
+                let future = run_rest_server(config.clone(), database.clone())
+                    .map(|res| res.map_err(|e| ComponentError::runtime_error(self.name(), e)));
+                Ok(Some(Box::pin(future)))
+            } else {
+                info!("REST API server is disabled. Skipping...");
+                Ok(None)
+            }
+        } else {
+            info!("REST API server not configured. Skipping");
+            Ok(None)
+        }
+    }
+
+    fn name(&self) -> String {
+        "rest_api_server".to_string()
+    }
+}
+
+#[derive(new)]
+pub struct AdminApiComponent;
+
+#[async_trait]
+impl Component for AdminApiComponent {
+    async fn prepare_component_task(
+        &self,
+        config: &SidecarConfig,
+    ) -> Result<Option<BoxFuture<'_, Result<ExitCode, ComponentError>>>, ComponentError> {
+        if let Some(config) = &config.admin_api_server {
+            if config.enable_server {
+                let future = run_admin_server(config.clone())
+                    .map(|res| res.map_err(|e| ComponentError::runtime_error(self.name(), e)));
+                Ok(Some(Box::pin(future)))
+            } else {
+                info!("Admin API server is disabled. Skipping.");
+                Ok(None)
+            }
+        } else {
+            info!("Admin API server not configured. Skipping.");
+            Ok(None)
+        }
+    }
+
+    fn name(&self) -> String {
+        "admin_api_server".to_string()
+    }
+}
+
+#[derive(new)]
+pub struct RpcApiComponent;
+
+#[async_trait]
+impl Component for RpcApiComponent {
+    async fn prepare_component_task(
+        &self,
+        config: &SidecarConfig,
+    ) -> Result<Option<BoxFuture<'_, Result<ExitCode, ComponentError>>>, ComponentError> {
+        if let Some(config) = config.rpc_server.as_ref() {
+            let any_server_defined = config.main_server.enable_server
+                || config
+                    .speculative_exec_server
+                    .as_ref()
+                    .map(|x| x.enable_server)
+                    .unwrap_or(false);
+            if !any_server_defined {
+                //There was no main rpc server of speculative exec server configured, we shouldn't bother with proceeding
+                return Ok(None);
+            }
+            let res = build_rpc_server(config.clone()).await;
+            match res {
+                Ok(None) => Ok(None),
+                Ok(Some(fut)) => {
+                    let future = fut
+                        .map(|res| res.map_err(|e| ComponentError::runtime_error(self.name(), e)));
+                    Ok(Some(Box::pin(future)))
+                }
+                Err(err) => Err(ComponentError::initialization_error(self.name(), err)),
+            }
+        } else {
+            info!("RPC API server not configured. Skipping.");
+            Ok(None)
+        }
+    }
+
+    fn name(&self) -> String {
+        "rpc_api_server".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SidecarConfig;
+    use casper_rpc_sidecar::{
+        testing::{get_port, start_mock_binary_port_responding_with_stored_value},
+        NodeClientConfig, RpcServerConfig, SpeculativeExecConfig,
+    };
+
+    #[tokio::test]
+    async fn given_sse_server_component_when_no_db_should_return_none() {
+        let component = SseServerComponent::new(None);
+        let config = all_components_all_enabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_sse_server_component_when_db_but_no_config_should_return_none() {
+        let component = SseServerComponent::new(Some(Database::for_tests()));
+        let mut config = all_components_all_disabled();
+        config.sse_server = None;
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_sse_server_component_when_config_disabled_should_return_none() {
+        let component = SseServerComponent::new(Some(Database::for_tests()));
+        let config = all_components_all_disabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_sse_server_component_when_db_and_config_should_return_some() {
+        let component = SseServerComponent::new(Some(Database::for_tests()));
+        let config = all_components_all_enabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn given_rest_api_server_component_when_no_db_should_return_none() {
+        let component = RestApiComponent::new(None);
+        let config = all_components_all_enabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_rest_api_server_component_when_db_but_no_config_should_return_none() {
+        let component = RestApiComponent::new(Some(Database::for_tests()));
+        let mut config = all_components_all_disabled();
+        config.rest_api_server = None;
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_rest_api_server_component_when_config_disabled_should_return_none() {
+        let component = RestApiComponent::new(Some(Database::for_tests()));
+        let config = all_components_all_disabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_rest_api_server_component_when_db_and_config_should_return_some() {
+        let component = RestApiComponent::new(Some(Database::for_tests()));
+        let config = all_components_all_enabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn given_admin_api_server_component_when_no_config_should_return_none() {
+        let component = AdminApiComponent::new();
+        let mut config = all_components_all_disabled();
+        config.admin_api_server = None;
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_admin_api_server_component_when_config_disabled_should_return_none() {
+        let component = AdminApiComponent::new();
+        let config = all_components_all_disabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_admin_api_server_component_when_config_should_return_some() {
+        let component = AdminApiComponent::new();
+        let config = all_components_all_enabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn given_rpc_api_server_component_when_config_disabled_should_return_none() {
+        let component = RpcApiComponent::new();
+        let config = all_components_all_disabled();
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn given_rpc_api_server_component_when_config_should_return_some() {
+        let port = get_port();
+        let _mock_server_handle = start_mock_binary_port_responding_with_stored_value(port).await;
+        let component = RpcApiComponent::new();
+        let mut config = all_components_all_enabled();
+        config.rpc_server.as_mut().unwrap().node_client =
+            NodeClientConfig::finite_retries_config(port, 1);
+        config.rpc_server.as_mut().unwrap().main_server.address = format!("0.0.0.0:{}", port);
+        config
+            .rpc_server
+            .as_mut()
+            .unwrap()
+            .speculative_exec_server
+            .as_mut()
+            .unwrap()
+            .address = format!("0.0.0.0:{}", port);
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn given_rpc_api_server_component_when_no_config_should_return_none() {
+        let component = RpcApiComponent::new();
+        let mut config = all_components_all_disabled();
+        config.rpc_server = None;
+        let res = component.prepare_component_task(&config).await;
+        assert!(res.is_ok());
+        assert!(res.unwrap().is_none());
+    }
+
+    fn all_components_all_enabled() -> SidecarConfig {
+        let mut rpc_server = RpcServerConfig::default();
+        let speculative_config = SpeculativeExecConfig {
+            enable_server: true,
+            ..Default::default()
+        };
+        rpc_server.speculative_exec_server = Some(speculative_config);
+        SidecarConfig {
+            storage: Some(Default::default()),
+            admin_api_server: Some(Default::default()),
+            rest_api_server: Some(Default::default()),
+            sse_server: Some(Default::default()),
+            rpc_server: Some(rpc_server),
+            ..Default::default()
+        }
+    }
+
+    fn all_components_all_disabled() -> SidecarConfig {
+        let mut config = all_components_all_enabled();
+        config.admin_api_server.as_mut().unwrap().enable_server = false;
+        config.rest_api_server.as_mut().unwrap().enable_server = false;
+        config
+            .rpc_server
+            .as_mut()
+            .unwrap()
+            .main_server
+            .enable_server = false;
+        config
+            .rpc_server
+            .as_mut()
+            .unwrap()
+            .speculative_exec_server
+            .as_mut()
+            .unwrap()
+            .enable_server = false;
+        config.sse_server.as_mut().unwrap().enable_server = false;
+        config
+    }
+}

--- a/sidecar/src/main.rs
+++ b/sidecar/src/main.rs
@@ -1,12 +1,12 @@
+pub mod component;
 mod config;
+mod run;
 
 use anyhow::{Context, Error};
 use backtrace::Backtrace;
-use casper_event_sidecar::{run as run_sse_sidecar, run_admin_server, run_rest_server, Database};
-use casper_rpc_sidecar::start_rpc_server as run_rpc_sidecar;
 use clap::Parser;
 use config::{SidecarConfig, SidecarConfigTarget};
-use futures::FutureExt;
+use run::run;
 use std::{
     env, fmt, io,
     panic::{self, PanicInfo},
@@ -66,56 +66,6 @@ pub fn read_config(config_path: &str) -> Result<SidecarConfigTarget, Error> {
     let toml_content =
         std::fs::read_to_string(config_path).context("Error reading config file contents")?;
     toml::from_str(&toml_content).context("Error parsing config into TOML format")
-}
-
-async fn run(config: SidecarConfig) -> Result<ExitCode, Error> {
-    let maybe_database = if let Some(storage_config) = config.storage.as_ref() {
-        Some(Database::build(storage_config).await?)
-    } else {
-        None
-    };
-    let admin_server = if let Some(config) = config.admin_api_server {
-        run_admin_server(config.clone()).boxed()
-    } else {
-        std::future::pending().boxed()
-    };
-    let rest_server = if let (Some(rest_config), Some(database)) =
-        (config.rest_api_server, maybe_database.clone())
-    {
-        run_rest_server(rest_config.clone(), database).boxed()
-    } else {
-        std::future::pending().boxed()
-    };
-
-    let sse_server = if let (Some(storage_config), Some(database), Some(sse_server_config)) =
-        (config.storage, maybe_database, config.sse_server)
-    {
-        // If sse server is configured, both storage config and database must be "Some" here. This should be ensured by prior validation.
-        run_sse_sidecar(
-            sse_server_config,
-            database.clone(),
-            storage_config.get_storage_path(),
-        )
-        .boxed()
-    } else {
-        std::future::pending().boxed()
-    };
-
-    let rpc_server = config.rpc_server.as_ref().map_or_else(
-        || std::future::pending().boxed(),
-        |conf| run_rpc_sidecar(conf).boxed(),
-    );
-
-    let result = tokio::select! {
-        result = admin_server => result,
-        result = rest_server => result,
-        result = sse_server => result,
-        result = rpc_server => result,
-    };
-    if let Err(error) = &result {
-        info!("The server has exited with an error: {}", error);
-    };
-    result
 }
 
 fn panic_hook(info: &PanicInfo) {

--- a/sidecar/src/run.rs
+++ b/sidecar/src/run.rs
@@ -1,0 +1,45 @@
+use crate::component::*;
+use crate::config::SidecarConfig;
+use anyhow::{anyhow, Error};
+use casper_event_sidecar::Database;
+use std::process::ExitCode;
+use tracing::info;
+
+pub async fn run(config: SidecarConfig) -> Result<ExitCode, Error> {
+    let maybe_database = if let Some(storage_config) = config.storage.as_ref() {
+        Some(Database::build(storage_config).await?)
+    } else {
+        None
+    };
+    let mut components: Vec<Box<dyn Component>> = Vec::new();
+    let admin_api_component = AdminApiComponent::new();
+    components.push(Box::new(admin_api_component));
+    let rest_api_component = RestApiComponent::new(maybe_database.clone());
+    components.push(Box::new(rest_api_component));
+    let sse_server_component = SseServerComponent::new(maybe_database);
+    components.push(Box::new(sse_server_component));
+    let rpc_api_component = RpcApiComponent::new();
+    components.push(Box::new(rpc_api_component));
+    do_run(config, components).await.map_err(|component_error| {
+        info!("The server has exited with an error: {}", component_error);
+        anyhow!(component_error.to_string())
+    })
+}
+
+async fn do_run(
+    config: SidecarConfig,
+    components: Vec<Box<dyn Component>>,
+) -> Result<ExitCode, ComponentError> {
+    if components.is_empty() {
+        info!("No sidecar components are defined/enabled. Exiting");
+        return Ok(ExitCode::SUCCESS);
+    }
+    let mut component_futures = Vec::new();
+    for component in components.iter() {
+        let maybe_future = component.prepare_component_task(&config).await?;
+        if let Some(future) = maybe_future {
+            component_futures.push(future);
+        }
+    }
+    futures::future::select_all(component_futures).await.0
+}


### PR DESCRIPTION
Introduced `enable_server` bool flag in the configuration of:
* Admin api server
* Rest api server
* SSE server
* RPC server
having `enable_server = false` means that the corresponding server will not start. Also, if all servers have `enable_server = false` sidecar will exit since it has nothing to do.