### PR TITLE
* Fixed import of dependency in `sqlite_database` - it caused bulding…

### DIFF
--- a/.github/workflows/ci-casper-event-sidecar-rs.yml
+++ b/.github/workflows/ci-casper-event-sidecar-rs.yml
@@ -1,5 +1,5 @@
 ---
-name: ci-casper-event-sidecar
+name: ci-casper-sidecar
 
 on:
   push:
@@ -53,12 +53,8 @@ jobs:
         run: cargo test
 
       - name: install cargo packaging tools
-        # TODO: fix deb package for feat-2.0
-        if: ${{ github.base_ref == null || github.base_ref == 'dev' }}
         run: |
           cargo install cargo-deb
 
       - name: deb
-        # TODO: fix deb package for feat-2.0
-        if: ${{ github.base_ref == null || github.base_ref == 'dev' }}
-        run: cargo deb --package casper-event-sidecar
+        run: cargo deb --package casper-sidecar

--- a/.github/workflows/publish-casper-event-sidecar-deb.yml
+++ b/.github/workflows/publish-casper-event-sidecar-deb.yml
@@ -1,5 +1,5 @@
 ---
-name: publish-casper-event-sidecar-deb
+name: publish-casper-sidecar-deb
 
 on:
   push:
@@ -74,6 +74,6 @@ jobs:
         uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575 #v2.3.0
         with:
           repo_token: ${{ secrets.TOKEN_FOR_GITHUB }}
-          file: target/debian/casper-event-sidecar/*
+          file: target/debian/casper-sidecar/*
           tag: ${{ github.ref }}
           file_glob: true

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The Sidecar application leverages tracing, which can be controlled by setting th
 The following command will run the sidecar application with the `INFO` log level.
 
 ```
-RUST_LOG=info cargo run -p casper-event-sidecar -- --path-to-config ./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
+RUST_LOG=info cargo run -p casper-sidecar -- --path-to-config ./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
 ```
 
 The log levels, listed in order of increasing verbosity, are:

--- a/ci/publish-casper-event-sidecar-crates.yml
+++ b/ci/publish-casper-event-sidecar-crates.yml
@@ -1,5 +1,5 @@
 ---
-name: publish-casper-event-sidecar-crates
+name: publish-casper-sidecar-crates
 
 on:
   push:

--- a/event_sidecar/Cargo.toml
+++ b/event_sidecar/Cargo.toml
@@ -66,27 +66,3 @@ reqwest = { version = "0.11.3", features = ["stream"] }
 tabled = { version = "0.10.0", features = ["derive", "color"] }
 tempfile = "3"
 tokio-util = "0.7.8"
-
-[package.metadata.deb]
-revision = "0"
-assets = [
-    ["../target/release/casper-event-sidecar", "/usr/bin/casper-event-sidecar", "755"],
-    ["../resources/ETC_README.md", "/etc/casper-event-sidecar/README.md", "644"],
-    ["../resources/example_configs/default_sse_only_config.toml", "/etc/casper-event-sidecar/config.toml", "644"]
-]
-maintainer-scripts = "../resources/maintainer_scripts/debian"
-extended-description = """
-Package for Casper Event Sidecar
-"""
-
-[package.metadata.deb.systemd-units]
-unit-scripts = "../resources/maintainer_scripts/casper_event_sidecar"
-restart-after-upgrade = true
-
-[package.metadata.deb.variants.bionic]
-name = "casper-event-sidecar"
-revision = "0+bionic"
-
-[package.metadata.deb.variants.focal]
-name = "casper-event-sidecar"
-revision = "0+focal"

--- a/event_sidecar/src/database/sqlite_database.rs
+++ b/event_sidecar/src/database/sqlite_database.rs
@@ -3,7 +3,7 @@ mod reader;
 mod tests;
 mod writer;
 use super::migration_manager::MigrationManager;
-#[cfg(test)]
+#[cfg(any(feature = "testing", test))]
 use crate::types::config::StorageConfig;
 use crate::{
     sql::tables,
@@ -96,8 +96,8 @@ impl SqliteDatabase {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl SqliteDatabase {
-    #[cfg(test)]
     pub async fn new_from_config(storage_config: &StorageConfig) -> Result<SqliteDatabase, Error> {
         match storage_config {
             StorageConfig::SqliteDbConfig {
@@ -110,7 +110,6 @@ impl SqliteDatabase {
         }
     }
 
-    #[cfg(any(feature = "testing", test))]
     pub async fn new_in_memory(max_connections: u32) -> Result<SqliteDatabase, Error> {
         let sqlite_db = Self::new_in_memory_no_migrations(max_connections)?;
         MigrationManager::apply_all_migrations(sqlite_db.clone()).await?;

--- a/event_sidecar/src/types/config.rs
+++ b/event_sidecar/src/types/config.rs
@@ -19,8 +19,7 @@ pub(crate) const DEFAULT_MAX_CONNECTIONS: u32 = 10;
 /// The default postgres port.
 pub(crate) const DEFAULT_PORT: u16 = 5432;
 
-pub(crate) const DEFAULT_POSTGRES_STORAGE_PATH: &str =
-    "/casper/sidecar-storage/casper-event-sidecar";
+pub(crate) const DEFAULT_POSTGRES_STORAGE_PATH: &str = "/casper/sidecar-storage/casper-sidecar";
 
 // This struct is used to parse the toml-formatted config file so the values can be utilised in the code.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]

--- a/resources/ETC_README.md
+++ b/resources/ETC_README.md
@@ -19,7 +19,7 @@ The SSE Sidecar uses one ring buffer for outbound events, providing some robustn
 
 ## Configuration
 
-The file `/etc/casper-event-sidecar/config.toml` holds a default configuration. This should work if installed on a Casper node.
+The file `/etc/casper-sidecar/config.toml` holds a default configuration. This should work if installed on a Casper node.
 
 If you install the Sidecar on an external server, you must update the `ip-address` values under `node_connections` appropriately.
 
@@ -82,7 +82,7 @@ This directory stores the SSE cache and an SQLite database if the Sidecar is con
 
 ```
 [storage]
-storage_path = "/var/lib/casper-event-sidecar"
+storage_path = "/var/lib/casper-sidecar"
 ```
 
 ### Database Connectivity
@@ -222,16 +222,16 @@ An OpenAPI schema is available at `http://localhost:18888/api-doc.json/`.
 
 ## Running the Event Sidecar
 
-The `casper-event-sidecar` service starts after installation, using the systemd service file.
+The `casper-sidecar` service starts after installation, using the systemd service file.
 
 ### Stop
 
-`sudo systemctl stop casper-event-sidecar.service`
+`sudo systemctl stop casper-sidecar.service`
 
 ### Start
 
-`sudo systemctl start casper-event-sidecar.service`
+`sudo systemctl start casper-sidecar.service`
 
 ### Logs
 
-`journalctl --no-pager -u casper-event-sidecar`
+`journalctl --no-pager -u casper-sidecar`

--- a/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
@@ -31,7 +31,7 @@ max_concurrent_subscribers = 100
 event_stream_buffer_length = 5000
 
 [storage]
-storage_path = "/var/lib/casper-event-sidecar"
+storage_path = "/var/lib/casper-sidecar"
 
 [storage.sqlite_config]
 file_name = "sqlite_database.db3"

--- a/resources/example_configs/default_sse_only_config.toml
+++ b/resources/example_configs/default_sse_only_config.toml
@@ -13,7 +13,7 @@ max_concurrent_subscribers = 100
 event_stream_buffer_length = 5000
 
 [storage]
-storage_path = "/var/lib/casper-event-sidecar"
+storage_path = "/var/lib/casper-sidecar"
 
 [storage.sqlite_config]
 file_name = "sqlite_database.db3"

--- a/resources/maintainer_scripts/casper_sidecar/casper-sidecar.service
+++ b/resources/maintainer_scripts/casper_sidecar/casper-sidecar.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Casper Event Sidecar
+Description=Casper Sidecar
 Documentation=https://docs.casperlabs.io
 After=network-online.target
 # Stop restarting after 3 failures in 15 seconds
@@ -8,7 +8,7 @@ StartLimitIntervalSec=15
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/casper-event-sidecar --path-to-config /etc/casper-event-sidecar/config.toml
+ExecStart=/usr/bin/casper-sidecar --path-to-config /etc/casper-sidecar/config.toml
 User=csidecar
 Group=csidecar
 Restart=on-failure

--- a/resources/maintainer_scripts/debian/postinst
+++ b/resources/maintainer_scripts/debian/postinst
@@ -4,8 +4,8 @@ set -e
 # Default Variables
 # ---
 DEFAULT_USERNAME="csidecar"
-DEFAULT_CONFIG_DIRECTORY="/etc/casper-event-sidecar"
-DEFAULT_DATA_DIRECTORY="/var/lib/casper-event-sidecar"
+DEFAULT_CONFIG_DIRECTORY="/etc/casper-sidecar"
+DEFAULT_DATA_DIRECTORY="/var/lib/casper-sidecar"
 
 # User Creation
 # ---

--- a/resources/maintainer_scripts/debian/preinst
+++ b/resources/maintainer_scripts/debian/preinst
@@ -4,8 +4,8 @@ set -e
 # Default Variables
 # ---
 DEFAULT_USERNAME="csidecar"
-DEFAULT_CONFIG_DIRECTORY="/etc/casper-event-sidecar"
-DEFAULT_DATA_DIRECTORY="/var/lib/casper-event-sidecar"
+DEFAULT_CONFIG_DIRECTORY="/etc/casper-sidecar"
+DEFAULT_DATA_DIRECTORY="/var/lib/casper-sidecar"
 
 # Creation of Files/Directories
 # ---

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -34,3 +34,28 @@ casper-rpc-sidecar = { workspace = true, features = ["testing"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"
+
+
+[package.metadata.deb]
+revision = "0"
+assets = [
+    ["../target/release/casper-sidecar", "/usr/bin/casper-sidecar", "755"],
+    ["../resources/ETC_README.md", "/etc/casper-sidecar/README.md", "644"],
+    ["../resources/example_configs/default_rpc_only_config.toml", "/etc/casper-sidecar/config.toml", "644"]
+]
+maintainer-scripts = "../resources/maintainer_scripts/debian"
+extended-description = """
+Package for Casper Event Sidecar
+"""
+
+[package.metadata.deb.systemd-units]
+unit-scripts = "../resources/maintainer_scripts/casper_sidecar"
+restart-after-upgrade = true
+
+[package.metadata.deb.variants.bionic]
+name = "casper-sidecar"
+revision = "0+bionic"
+
+[package.metadata.deb.variants.focal]
+name = "casper-sidecar"
+revision = "0+focal"


### PR DESCRIPTION
… a package to fail

* Removing lingering references to "casper-event-sidecar". The whole project should now be called "casper-sidecar"
* Moving packaging configuration from "event-sidecar" module to "sidecar" which aggrgates the final binary