### PR TITLE
Added metrics that trace response time of RPC methods. Removed PATH_A…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "http",
  "hyper",
  "juliet",
+ "metrics",
  "num_cpus",
  "once_cell",
  "portpicker",

--- a/event_sidecar/src/lib.rs
+++ b/event_sidecar/src/lib.rs
@@ -51,12 +51,13 @@ use utils::start_metrics_thread;
 
 pub use admin_server::run_server as run_admin_server;
 pub use database::DatabaseConfigError;
-pub use types::config::{
-    AdminApiServerConfig, Connection, RestApiServerConfig, SseEventServerConfig, StorageConfig,
-    StorageConfigSerdeTarget,
+pub use types::{
+    config::{
+        AdminApiServerConfig, Connection, RestApiServerConfig, SseEventServerConfig, StorageConfig,
+        StorageConfigSerdeTarget,
+    },
+    database::{Database, LazyDatabaseWrapper},
 };
-
-pub type Database = types::database::Database;
 
 const DEFAULT_CHANNEL_SIZE: usize = 1000;
 

--- a/event_sidecar/src/rest_server.rs
+++ b/event_sidecar/src/rest_server.rs
@@ -9,9 +9,8 @@ mod tests;
 
 use anyhow::Error;
 use hyper::Server;
-use metrics::rest_api::observe_path_abstraction_time;
+use std::net::TcpListener;
 use std::time::Duration;
-use std::{net::TcpListener, time::Instant};
 use tower::{buffer::Buffer, make::Shared, ServiceBuilder};
 use tracing::info;
 use warp::Filter;
@@ -52,15 +51,7 @@ pub async fn run_server<Db: DatabaseReader + Clone + Send + Sync + 'static>(
     Err(Error::msg("REST server shutting down"))
 }
 
-fn path_abstraction_for_metrics(path: &str) -> String {
-    let start = Instant::now();
-    let result = path_abstraction_for_metrics_inner(path);
-    let elapsed = start.elapsed();
-    observe_path_abstraction_time(elapsed);
-    result
-}
-
-pub(super) fn path_abstraction_for_metrics_inner(path: &str) -> String {
+pub(super) fn path_abstraction_for_metrics(path: &str) -> String {
     let parts = path
         .split('/')
         .filter(|el| !el.is_empty())

--- a/event_sidecar/src/tests.rs
+++ b/event_sidecar/src/tests.rs
@@ -1,11 +1,11 @@
-use crate::rest_server::path_abstraction_for_metrics_inner;
+use crate::rest_server::path_abstraction_for_metrics;
 
 pub mod integration_tests;
 pub mod integration_tests_version_switch;
 pub mod performance_tests;
 
 #[test]
-fn path_abstraction_for_metrics_inner_should_handle_endpoints() {
+fn path_abstraction_for_metrics_should_handle_endpoints() {
     test_single_nested_path("block");
     test_single_nested_path("step");
     test_single_nested_path("faults");
@@ -50,5 +50,5 @@ fn test_single_nested_path(part: &str) {
 }
 
 fn expect_output(input: &str, output: &str) {
-    assert_eq!(path_abstraction_for_metrics_inner(input), output);
+    assert_eq!(path_abstraction_for_metrics(input), output);
 }

--- a/metrics/src/rest_api.rs
+++ b/metrics/src/rest_api.rs
@@ -1,11 +1,12 @@
 use super::REGISTRY;
 use once_cell::sync::Lazy;
-use prometheus::{Histogram, HistogramOpts, HistogramVec, IntGauge, Opts};
+use prometheus::{HistogramOpts, HistogramVec, IntGauge, Opts};
 use std::time::Duration;
 
 const RESPONSE_TIME_MS_BUCKETS: &[f64; 8] = &[
     1_f64, 5_f64, 10_f64, 30_f64, 50_f64, 100_f64, 200_f64, 300_f64,
 ];
+
 static CONNECTED_CLIENTS: Lazy<IntGauge> = Lazy::new(|| {
     let counter = IntGauge::new("rest_api_connected_clients", "Connected Clients")
         .expect("rest_api_connected_clients metric can't be created");
@@ -20,7 +21,7 @@ static RESPONSE_TIMES_MS: Lazy<HistogramVec> = Lazy::new(|| {
         HistogramOpts {
             common_opts: Opts::new(
                 "rest_api_response_times",
-                "Time it takes the service to prepare a response in milliseconds",
+                "Time it takes the service to produce a response in milliseconds",
             ),
             buckets: Vec::from(RESPONSE_TIME_MS_BUCKETS as &'static [f64]),
         },
@@ -31,23 +32,6 @@ static RESPONSE_TIMES_MS: Lazy<HistogramVec> = Lazy::new(|| {
         .register(Box::new(counter.clone()))
         .expect("cannot register metric");
     counter
-});
-
-const PATH_ABSTRACTION_TIMES_BUCKETS: &[f64; 5] =
-    &[1e-6_f64, 1e-5_f64, 1e-4_f64, 1e-3_f64, 1e-2_f64];
-
-static PATH_ABSTRACTION_TIMES_SECONDS: Lazy<Histogram> = Lazy::new(|| {
-    let opts = HistogramOpts::new(
-        "rest_api_path_abbreviation",
-        "How long path abbreviation takes in seconds",
-    )
-    .buckets(PATH_ABSTRACTION_TIMES_BUCKETS.to_vec());
-    let histogram = Histogram::with_opts(opts).unwrap();
-
-    REGISTRY
-        .register(Box::new(histogram.clone()))
-        .expect("cannot register metric");
-    histogram
 });
 
 pub fn inc_connected_clients() {
@@ -63,10 +47,4 @@ pub fn observe_response_time(label: &str, status: &str, response_time: Duration)
     RESPONSE_TIMES_MS
         .with_label_values(&[label, status])
         .observe(response_time);
-}
-
-//TODO keep this for testing to see what is the impact, but eventaully this should be removed
-pub fn observe_path_abstraction_time(elapsed: Duration) {
-    let elapsed = elapsed.as_secs_f64();
-    PATH_ABSTRACTION_TIMES_SECONDS.observe(elapsed);
 }

--- a/metrics/src/rpc.rs
+++ b/metrics/src/rpc.rs
@@ -1,9 +1,15 @@
+use std::time::Duration;
+
 use super::REGISTRY;
 use once_cell::sync::Lazy;
-use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts};
+use prometheus::{Histogram, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts};
 
 const RESPONSE_SIZE_BUCKETS: &[f64; 8] = &[
     5e+2_f64, 1e+3_f64, 2e+3_f64, 5e+3_f64, 5e+4_f64, 5e+5_f64, 5e+6_f64, 5e+7_f64,
+];
+
+const RESPONSE_TIME_MS_BUCKETS: &[f64; 8] = &[
+    1_f64, 5_f64, 10_f64, 30_f64, 50_f64, 100_f64, 200_f64, 300_f64,
 ];
 
 static ENDPOINT_CALLS: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -18,12 +24,44 @@ static ENDPOINT_CALLS: Lazy<IntCounterVec> = Lazy::new(|| {
     counter
 });
 
-static ENDPOINT_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
-    let counter = IntCounterVec::new(
-        Opts::new("rpc_server_endpoint_responses", "Endpoint responses"),
-        &["endpoint", "status"],
+static RESPONSE_TIMES_MS: Lazy<HistogramVec> = Lazy::new(|| {
+    let histogram = HistogramVec::new(
+        HistogramOpts {
+            common_opts: Opts::new(
+                "rpc_server_endpoint_response_times",
+                "Time it takes the service to produce a response in milliseconds",
+            ),
+            buckets: Vec::from(RESPONSE_TIME_MS_BUCKETS as &'static [f64]),
+        },
+        &["method", "status"],
     )
-    .unwrap();
+    .expect("rpc_server_endpoint_response_times metric can't be created");
+    REGISTRY
+        .register(Box::new(histogram.clone()))
+        .expect("cannot register metric");
+    histogram
+});
+
+static RECONNECT_TIMES_MS: Lazy<Histogram> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "rpc_server_reconnect_time",
+        "Time it takes the service to reconnect to node binary port in milliseconds",
+    )
+    .buckets(RESPONSE_TIME_MS_BUCKETS.to_vec());
+    let histogram =
+        Histogram::with_opts(opts).expect("rpc_server_reconnect_time metric can't be created");
+    REGISTRY
+        .register(Box::new(histogram.clone()))
+        .expect("cannot register metric");
+    histogram
+});
+
+static DISCONNECT_EVENTS: Lazy<IntGauge> = Lazy::new(|| {
+    let counter = IntGauge::new(
+        "rpc_server_disconnects",
+        "Number of TCP disconnects between sidecar and nodes binary port",
+    )
+    .expect("rpc_server_disconnects metric can't be created");
     REGISTRY
         .register(Box::new(counter.clone()))
         .expect("cannot register metric");
@@ -49,10 +87,20 @@ pub fn inc_method_call(method: &str) {
     ENDPOINT_CALLS.with_label_values(&[method]).inc();
 }
 
-pub fn inc_result(method: &str, status: &str) {
-    ENDPOINT_RESPONSES
+pub fn observe_response_time(method: &str, status: &str, response_time: Duration) {
+    let response_time = response_time.as_secs_f64() * 1000.0;
+    RESPONSE_TIMES_MS
         .with_label_values(&[method, &status])
-        .inc();
+        .observe(response_time);
+}
+
+pub fn observe_reconnect_time(response_time: Duration) {
+    let response_time = response_time.as_secs_f64() * 1000.0;
+    RECONNECT_TIMES_MS.observe(response_time);
+}
+
+pub fn inc_disconnect() {
+    DISCONNECT_EVENTS.inc();
 }
 
 pub fn register_request_size(method: &str, payload_size: f64) {

--- a/rpc_sidecar/Cargo.toml
+++ b/rpc_sidecar/Cargo.toml
@@ -24,6 +24,7 @@ futures = { workspace = true }
 http = "0.2.1"
 hyper = "0.14.26"
 juliet = { version ="0.3", features = ["tracing"] }
+metrics = { workspace = true }
 num_cpus = "1"
 once_cell.workspace = true
 portpicker = "0.1.1"

--- a/sidecar/src/run.rs
+++ b/sidecar/src/run.rs
@@ -1,16 +1,15 @@
 use crate::component::*;
 use crate::config::SidecarConfig;
 use anyhow::{anyhow, Error};
-use casper_event_sidecar::Database;
+use casper_event_sidecar::LazyDatabaseWrapper;
 use std::process::ExitCode;
 use tracing::info;
 
 pub async fn run(config: SidecarConfig) -> Result<ExitCode, Error> {
-    let maybe_database = if let Some(storage_config) = config.storage.as_ref() {
-        Some(Database::build(storage_config).await?)
-    } else {
-        None
-    };
+    let maybe_database = config
+        .storage
+        .as_ref()
+        .map(|storage_config| LazyDatabaseWrapper::new(storage_config.clone()));
     let mut components: Vec<Box<dyn Component>> = Vec::new();
     let admin_api_component = AdminApiComponent::new();
     components.push(Box::new(admin_api_component));


### PR DESCRIPTION
…BSTRACTION_TIMES_SECONDS which was a temporary check and ment to be removed. Made databse initialization lazy. This ensures that if no db-dependant component starts there will be no DB connection initialization (since it's not needed)