### PR TITLE
Use EntityAddr instead of AddressableEntityHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
 dependencies = [
  "brotli",
  "flate2",
@@ -239,7 +239,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "4.0.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125740193d7fee5cc63ab9e16c2fdc4e07c74ba755cc53b327d6ea029e9fc569"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "3.0.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65622a320492e09b5e0ac436b14c54ff68199bac392d0e89a6832c4518eea525"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -468,7 +468,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#288f0be84226806a70d5818a25480c3c2d346fab"
+source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#eb60995e15e3646dbacb1ccfc439e910108b07e7"
 dependencies = [
  "bincode",
  "casper-types",
@@ -566,7 +566,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hex_fmt",
- "http 0.2.12",
+ "http",
  "hyper",
  "indexmap 2.2.6",
  "itertools 0.10.5",
@@ -624,7 +624,7 @@ dependencies = [
  "bytes",
  "env_logger",
  "futures",
- "http 0.2.12",
+ "http",
  "hyper",
  "itertools 0.10.5",
  "metrics",
@@ -651,7 +651,7 @@ dependencies = [
  "casper-types",
  "datasize",
  "futures",
- "http 0.2.12",
+ "http",
  "hyper",
  "juliet",
  "metrics",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "3.0.0"
-source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#288f0be84226806a70d5818a25480c3c2d346fab"
+source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#eb60995e15e3646dbacb1ccfc439e910108b07e7"
 dependencies = [
  "base16",
  "base64 0.13.1",
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.91"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd97381a8cc6493395a5afc4c691c1084b3768db713b73aa215217aa245d153"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
  "libc",
@@ -804,7 +804,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -816,7 +816,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b432c56615136f8dba245fed7ec3d5518c500a31108661067e61e72fe7e6bc"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]
@@ -1002,7 +1002,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1035,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1072,7 +1072,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1514,7 +1514,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.13"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06fddc2749e0528d2813f95e050e87e52c8cbbae56223b9babf73b3e53b0cc6"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1843,7 +1843,7 @@ checksum = "1dff438f14e67e7713ab9332f5fd18c8f20eb7eb249494f6c2bf170522224032"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2090,16 +2090,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -2141,7 +2141,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 0.2.12",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2153,7 +2153,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.12",
+ "http",
 ]
 
 [[package]]
@@ -2256,24 +2256,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.12",
+ "http",
  "pin-project-lite",
 ]
 
@@ -2306,7 +2295,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -2372,7 +2361,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2544,12 +2533,13 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -2623,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
@@ -2714,7 +2704,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 0.2.12",
+ "http",
  "httparse",
  "log",
  "memchr",
@@ -2941,7 +2931,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2952,9 +2942,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -3135,14 +3125,14 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3433,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
  "libredox",
@@ -3498,7 +3488,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -3608,7 +3598,7 @@ dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
  "rust-embed-utils",
- "syn 2.0.58",
+ "syn 2.0.55",
  "walkdir",
 ]
 
@@ -3687,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rusty-fork"
@@ -3793,7 +3783,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
  "thiserror",
 ]
 
@@ -3812,9 +3802,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -3825,9 +3815,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3875,7 +3865,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -3981,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "slab"
@@ -4359,9 +4349,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "structopt"
@@ -4428,7 +4418,7 @@ dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4461,9 +4451,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
@@ -4580,7 +4570,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4663,9 +4653,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4688,7 +4678,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4726,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -4807,7 +4797,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4870,14 +4860,14 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand",
@@ -5033,7 +5023,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5145,16 +5135,16 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.7"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
 dependencies = [
  "async-compression",
  "bytes",
  "futures-channel",
  "futures-util",
  "headers",
- "http 0.2.12",
+ "http",
  "hyper",
  "log",
  "mime",
@@ -5162,11 +5152,13 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project",
+ "rustls-pemfile",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tower-service",
@@ -5206,7 +5198,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -5240,7 +5232,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5601,7 +5593,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",
- "syn 2.0.58",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5651,9 +5643,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
  "pkg-config",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -798,7 +798,42 @@
             {
               "name": "entity_identifier",
               "value": {
-                "EntityHashForAccount": "addressable-entity-0000000000000000000000000000000000000000000000000000000000000000"
+                "EntityAddr": {
+                  "Account": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ]
+                }
               }
             },
             {
@@ -6383,27 +6418,58 @@
             "additionalProperties": false
           },
           {
-            "description": "The hash of an addressable entity representing an account.",
+            "description": "The address of an addressable entity.",
             "type": "object",
             "required": [
-              "EntityHashForAccount"
+              "EntityAddr"
             ],
             "properties": {
-              "EntityHashForAccount": {
-                "$ref": "#/components/schemas/AddressableEntityHash"
+              "EntityAddr": {
+                "$ref": "#/components/schemas/EntityAddr"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "EntityAddr": {
+        "description": "The address for an AddressableEntity which contains the 32 bytes and tagging information.",
+        "oneOf": [
+          {
+            "description": "The address for a system entity account or contract.",
+            "type": "object",
+            "required": [
+              "System"
+            ],
+            "properties": {
+              "System": {
+                "type": "string"
               }
             },
             "additionalProperties": false
           },
           {
-            "description": "The hash of an addressable entity representing a contract.",
+            "description": "The address of an entity that corresponds to an Account.",
             "type": "object",
             "required": [
-              "EntityHashForContract"
+              "Account"
             ],
             "properties": {
-              "EntityHashForContract": {
-                "$ref": "#/components/schemas/AddressableEntityHash"
+              "Account": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "The address of an entity that corresponds to a Userland smart contract.",
+            "type": "object",
+            "required": [
+              "SmartContract"
+            ],
+            "properties": {
+              "SmartContract": {
+                "type": "string"
               }
             },
             "additionalProperties": false

--- a/rpc_sidecar/src/rpcs/common.rs
+++ b/rpc_sidecar/src/rpcs/common.rs
@@ -5,10 +5,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::rpcs::error::Error;
 use casper_types::{
-    account::AccountHash, addressable_entity::EntityKindTag, bytesrepr::ToBytes,
-    global_state::TrieMerkleProof, Account, AddressableEntity, AddressableEntityHash,
-    AvailableBlockRange, BlockHeader, BlockIdentifier, GlobalStateIdentifier, Key, SignedBlock,
-    StoredValue, URef, U512,
+    account::AccountHash, bytesrepr::ToBytes, global_state::TrieMerkleProof, Account,
+    AddressableEntity, AvailableBlockRange, BlockHeader, BlockIdentifier, EntityAddr,
+    GlobalStateIdentifier, Key, SignedBlock, StoredValue, URef, U512,
 };
 
 use crate::NodeClient;
@@ -156,13 +155,12 @@ pub async fn resolve_account_hash(
     }))
 }
 
-pub async fn resolve_entity_hash(
+pub async fn resolve_entity_addr(
     node_client: &dyn NodeClient,
-    tag: EntityKindTag,
-    entity_hash: AddressableEntityHash,
+    entity_addr: EntityAddr,
     state_identifier: Option<GlobalStateIdentifier>,
 ) -> Result<Option<SuccessfulQueryResult<AddressableEntity>>, Error> {
-    let entity_key = Key::addressable_entity_key(tag, entity_hash);
+    let entity_key = Key::AddressableEntity(entity_addr);
     let Some((value, merkle_proof)) = node_client
         .query_global_state(state_identifier, entity_key, vec![])
         .await

--- a/rpc_sidecar/src/rpcs/state.rs
+++ b/rpc_sidecar/src/rpcs/state.rs
@@ -79,9 +79,7 @@ static GET_ACCOUNT_INFO_RESULT: Lazy<GetAccountInfoResult> = Lazy::new(|| GetAcc
 });
 static GET_ADDRESSABLE_ENTITY_PARAMS: Lazy<GetAddressableEntityParams> =
     Lazy::new(|| GetAddressableEntityParams {
-        entity_identifier: EntityIdentifier::EntityHashForAccount(AddressableEntityHash::new(
-            [0; 32],
-        )),
+        entity_identifier: EntityIdentifier::EntityAddr(EntityAddr::new_account([0; 32])),
         block_identifier: Some(BlockIdentifier::Hash(*BlockHash::example())),
     });
 static GET_ADDRESSABLE_ENTITY_RESULT: Lazy<GetAddressableEntityResult> =
@@ -488,20 +486,17 @@ pub enum EntityIdentifier {
     PublicKey(PublicKey),
     /// The account hash of an account.
     AccountHash(AccountHash),
-    /// The hash of an addressable entity representing an account.
-    EntityHashForAccount(AddressableEntityHash),
-    /// The hash of an addressable entity representing a contract.
-    EntityHashForContract(AddressableEntityHash),
+    /// The address of an addressable entity.
+    EntityAddr(EntityAddr),
 }
 
 impl EntityIdentifier {
     #[cfg(test)]
     pub fn random(rng: &mut TestRng) -> Self {
-        match rng.gen_range(0..4) {
+        match rng.gen_range(0..3) {
             0 => EntityIdentifier::PublicKey(PublicKey::random(rng)),
             1 => EntityIdentifier::AccountHash(rng.gen()),
-            2 => EntityIdentifier::EntityHashForAccount(rng.gen()),
-            3 => EntityIdentifier::EntityHashForContract(rng.gen()),
+            2 => EntityIdentifier::EntityAddr(rng.gen()),
             _ => unreachable!(),
         }
     }
@@ -557,23 +552,10 @@ impl RpcWithParams for GetAddressableEntity {
     ) -> Result<Self::ResponseResult, RpcError> {
         let state_identifier = params.block_identifier.map(GlobalStateIdentifier::from);
         let (entity, merkle_proof) = match params.entity_identifier {
-            EntityIdentifier::EntityHashForAccount(hash) => {
-                let tag = EntityKindTag::Account;
-                let result =
-                    common::resolve_entity_hash(&*node_client, tag, hash, state_identifier)
-                        .await?
-                        .ok_or(Error::AddressableEntityNotFound)?;
-                (
-                    EntityOrAccount::AddressableEntity(result.value),
-                    result.merkle_proof,
-                )
-            }
-            EntityIdentifier::EntityHashForContract(hash) => {
-                let tag = EntityKindTag::SmartContract;
-                let result =
-                    common::resolve_entity_hash(&*node_client, tag, hash, state_identifier)
-                        .await?
-                        .ok_or(Error::AddressableEntityNotFound)?;
+            EntityIdentifier::EntityAddr(addr) => {
+                let result = common::resolve_entity_addr(&*node_client, addr, state_identifier)
+                    .await?
+                    .ok_or(Error::AddressableEntityNotFound)?;
                 (
                     EntityOrAccount::AddressableEntity(result.value),
                     result.merkle_proof,
@@ -1395,7 +1377,7 @@ mod tests {
 
         let rng = &mut TestRng::new();
         let block = Block::V2(TestBlockBuilder::new().build(rng));
-        let entity_identifier = EntityIdentifier::EntityHashForAccount(rng.gen());
+        let entity_identifier = EntityIdentifier::EntityAddr(rng.gen());
 
         let err = GetAddressableEntity::do_handle_request(
             Arc::new(ClientMock {


### PR DESCRIPTION
The initial code was written before EntityAddr was introduced, so we didn't use it, but now that EntityAddr exists, it should be used here instead for consistency with other code (like for example GetDictionaryItem).

Depends on https://github.com/casper-network/casper-node/pull/4653.