### PR TITLE
Execution result should be null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
+checksum = "4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693"
 dependencies = [
  "brotli",
  "flate2",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125740193d7fee5cc63ab9e16c2fdc4e07c74ba755cc53b327d6ea029e9fc569"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65622a320492e09b5e0ac436b14c54ff68199bac392d0e89a6832c4518eea525"
+checksum = "e6221fe77a248b9117d431ad93761222e1cf8ff282d9d1d5d9f53d6299a1cf76"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/rafal-ch/casper-node?branch=julietless_node_2#33415a5a0b26757ac21ce62a457d8481940904e1"
+source = "git+https://github.com/rafal-ch/casper-node?branch=julietless_node_2#3b6ad2d4f727d2e61870f31a945d0f260500aa51"
 dependencies = [
  "bincode",
  "bytes",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/rafal-ch/casper-node?branch=julietless_node_2#33415a5a0b26757ac21ce62a457d8481940904e1"
+source = "git+https://github.com/rafal-ch/casper-node?branch=julietless_node_2#3b6ad2d4f727d2e61870f31a945d0f260500aa51"
 dependencies = [
  "base16",
  "base64 0.13.1",
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "datasize"
@@ -1266,9 +1266,9 @@ checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "ff"
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "filetime"
@@ -1294,7 +1294,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
@@ -1306,9 +1306,9 @@ checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1713,7 +1713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
 dependencies = [
  "gix-hash",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "parking_lot",
 ]
 
@@ -1737,7 +1737,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix 0.38.33",
+ "rustix 0.38.34",
  "smallvec",
  "thiserror",
 ]
@@ -2033,9 +2033,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -2047,7 +2047,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2260,7 +2260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -2336,9 +2336,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -2468,9 +2468,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2880,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2890,15 +2890,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3268,6 +3268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.33"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cc72858054fcff6d7dea32df2aeaee6a7c24227366d7ea429aada2f26b16ad"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -3487,9 +3496,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "ring",
  "rustls-webpki",
@@ -3559,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+checksum = "7f55c82c700538496bdc329bb4918a81f87cc8888811bd123cf325a0f2f8d309"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
@@ -3572,14 +3581,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+checksum = "83263746fe5e32097f06356968a077f96089739c927a61450efa069905eec108"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
  "serde_derive_internals",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3671,9 +3680,9 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -3699,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -3710,13 +3719,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3832,9 +3841,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4251,7 +4260,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix 0.38.33",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -4650,9 +4659,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
@@ -4981,7 +4990,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "wasite",
 ]
 
@@ -5003,11 +5012,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5248,7 +5257,7 @@ checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
  "linux-raw-sys 0.4.13",
- "rustix 0.38.33",
+ "rustix 0.38.34",
 ]
 
 [[package]]

--- a/json_rpc/src/error.rs
+++ b/json_rpc/src/error.rs
@@ -102,7 +102,6 @@ pub struct Error {
     /// A short description of the error.
     message: Cow<'static, str>,
     /// Additional information about the error.
-    #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<Value>,
 }
 
@@ -219,7 +218,8 @@ mod tests {
     fn should_construct_reserved_error() {
         const EXPECTED_WITH_DATA: &str =
             r#"{"code":-32700,"message":"Parse error","data":{"id":1314,"context":"TEST"}}"#;
-        const EXPECTED_WITHOUT_DATA: &str = r#"{"code":-32601,"message":"Method not found"}"#;
+        const EXPECTED_WITHOUT_DATA: &str =
+            r#"{"code":-32601,"message":"Method not found","data":null}"#;
         const EXPECTED_WITH_BAD_DATA: &str = r#"{"code":-32603,"message":"Internal error","data":"failed to json-encode additional info in json-rpc error: won't encode"}"#;
 
         let error_with_data = Error::new(ReservedErrorCode::ParseError, AdditionalInfo::default());
@@ -239,7 +239,8 @@ mod tests {
     fn should_construct_custom_error() {
         const EXPECTED_WITH_DATA: &str =
             r#"{"code":-123,"message":"Valid test error","data":{"id":1314,"context":"TEST"}}"#;
-        const EXPECTED_WITHOUT_DATA: &str = r#"{"code":-123,"message":"Valid test error"}"#;
+        const EXPECTED_WITHOUT_DATA: &str =
+            r#"{"code":-123,"message":"Valid test error","data":null}"#;
         const EXPECTED_WITH_BAD_DATA: &str = r#"{"code":-32603,"message":"Internal error","data":"failed to json-encode additional info in json-rpc error: won't encode"}"#;
 
         let good_error_code = TestErrorCode {

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -286,21 +286,11 @@
               "description": "The deploy.",
               "$ref": "#/components/schemas/Deploy"
             },
-            "block_hash": {
-              "description": "The hash of the block in which the deploy was executed.",
-              "$ref": "#/components/schemas/BlockHash"
-            },
-            "block_height": {
-              "description": "The height of the block in which the deploy was executed.",
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            },
-            "execution_result": {
-              "description": "The execution result if known.",
+            "execution_info": {
+              "description": "Execution info, if available.",
               "anyOf": [
                 {
-                  "$ref": "#/components/schemas/ExecutionResult"
+                  "$ref": "#/components/schemas/ExecutionInfo"
                 },
                 {
                   "type": "null"
@@ -378,53 +368,55 @@
                   }
                 ]
               },
-              "block_hash": "6a2dad7a71608f78e9b6b5f97eed60a374e75e70cb8cc925e6681c61c84165bd",
-              "block_height": 10,
-              "execution_result": {
-                "Version2": {
-                  "initiator": {
-                    "PublicKey": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
-                  },
-                  "error_message": null,
-                  "limit": "123456",
-                  "consumed": "100000",
-                  "cost": "246912",
-                  "payment": [
-                    {
-                      "source": "uref-0101010101010101010101010101010101010101010101010101010101010101-001"
-                    }
-                  ],
-                  "transfers": [
-                    {
-                      "Version2": {
-                        "transaction_hash": {
-                          "Version1": "0101010101010101010101010101010101010101010101010101010101010101"
-                        },
-                        "from": {
-                          "AccountHash": "account-hash-0202020202020202020202020202020202020202020202020202020202020202"
-                        },
-                        "to": "account-hash-0303030303030303030303030303030303030303030303030303030303030303",
-                        "source": "uref-0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a-007",
-                        "target": "uref-1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b-000",
-                        "amount": "1000000000000",
-                        "gas": "2500000000",
-                        "id": 999
-                      }
-                    }
-                  ],
-                  "size_estimate": 186,
-                  "effects": [
-                    {
-                      "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
-                      "kind": {
-                        "AddUInt64": 8
-                      }
+              "execution_info": {
+                "block_hash": "6a2dad7a71608f78e9b6b5f97eed60a374e75e70cb8cc925e6681c61c84165bd",
+                "block_height": 10,
+                "execution_result": {
+                  "Version2": {
+                    "initiator": {
+                      "PublicKey": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
                     },
-                    {
-                      "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
-                      "kind": "Identity"
-                    }
-                  ]
+                    "error_message": null,
+                    "limit": "123456",
+                    "consumed": "100000",
+                    "cost": "246912",
+                    "payment": [
+                      {
+                        "source": "uref-0101010101010101010101010101010101010101010101010101010101010101-001"
+                      }
+                    ],
+                    "transfers": [
+                      {
+                        "Version2": {
+                          "transaction_hash": {
+                            "Version1": "0101010101010101010101010101010101010101010101010101010101010101"
+                          },
+                          "from": {
+                            "AccountHash": "account-hash-0202020202020202020202020202020202020202020202020202020202020202"
+                          },
+                          "to": "account-hash-0303030303030303030303030303030303030303030303030303030303030303",
+                          "source": "uref-0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a-007",
+                          "target": "uref-1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b-000",
+                          "amount": "1000000000000",
+                          "gas": "2500000000",
+                          "id": 999
+                        }
+                      }
+                    ],
+                    "size_estimate": 186,
+                    "effects": [
+                      {
+                        "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
+                        "kind": {
+                          "AddUInt64": 8
+                        }
+                      },
+                      {
+                        "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
+                        "kind": "Identity"
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -472,21 +464,11 @@
               "description": "The transaction.",
               "$ref": "#/components/schemas/Transaction"
             },
-            "block_hash": {
-              "description": "The hash of the block in which the deploy was executed.",
-              "$ref": "#/components/schemas/BlockHash"
-            },
-            "block_height": {
-              "description": "The height of the block in which the deploy was executed.",
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            },
-            "execution_result": {
-              "description": "The execution result if known.",
+            "execution_info": {
+              "description": "Execution info, if available.",
               "anyOf": [
                 {
-                  "$ref": "#/components/schemas/ExecutionResult"
+                  "$ref": "#/components/schemas/ExecutionInfo"
                 },
                 {
                   "type": "null"
@@ -584,53 +566,55 @@
                   ]
                 }
               },
-              "block_hash": "6a2dad7a71608f78e9b6b5f97eed60a374e75e70cb8cc925e6681c61c84165bd",
-              "block_height": 10,
-              "execution_result": {
-                "Version2": {
-                  "initiator": {
-                    "PublicKey": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
-                  },
-                  "error_message": null,
-                  "limit": "123456",
-                  "consumed": "100000",
-                  "cost": "246912",
-                  "payment": [
-                    {
-                      "source": "uref-0101010101010101010101010101010101010101010101010101010101010101-001"
-                    }
-                  ],
-                  "transfers": [
-                    {
-                      "Version2": {
-                        "transaction_hash": {
-                          "Version1": "0101010101010101010101010101010101010101010101010101010101010101"
-                        },
-                        "from": {
-                          "AccountHash": "account-hash-0202020202020202020202020202020202020202020202020202020202020202"
-                        },
-                        "to": "account-hash-0303030303030303030303030303030303030303030303030303030303030303",
-                        "source": "uref-0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a-007",
-                        "target": "uref-1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b-000",
-                        "amount": "1000000000000",
-                        "gas": "2500000000",
-                        "id": 999
-                      }
-                    }
-                  ],
-                  "size_estimate": 186,
-                  "effects": [
-                    {
-                      "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
-                      "kind": {
-                        "AddUInt64": 8
-                      }
+              "execution_info": {
+                "block_hash": "6a2dad7a71608f78e9b6b5f97eed60a374e75e70cb8cc925e6681c61c84165bd",
+                "block_height": 10,
+                "execution_result": {
+                  "Version2": {
+                    "initiator": {
+                      "PublicKey": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
                     },
-                    {
-                      "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
-                      "kind": "Identity"
-                    }
-                  ]
+                    "error_message": null,
+                    "limit": "123456",
+                    "consumed": "100000",
+                    "cost": "246912",
+                    "payment": [
+                      {
+                        "source": "uref-0101010101010101010101010101010101010101010101010101010101010101-001"
+                      }
+                    ],
+                    "transfers": [
+                      {
+                        "Version2": {
+                          "transaction_hash": {
+                            "Version1": "0101010101010101010101010101010101010101010101010101010101010101"
+                          },
+                          "from": {
+                            "AccountHash": "account-hash-0202020202020202020202020202020202020202020202020202020202020202"
+                          },
+                          "to": "account-hash-0303030303030303030303030303030303030303030303030303030303030303",
+                          "source": "uref-0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a-007",
+                          "target": "uref-1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b-000",
+                          "amount": "1000000000000",
+                          "gas": "2500000000",
+                          "id": 999
+                        }
+                      }
+                    ],
+                    "size_estimate": 186,
+                    "effects": [
+                      {
+                        "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
+                        "kind": {
+                          "AddUInt64": 8
+                        }
+                      },
+                      {
+                        "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
+                        "kind": "Identity"
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -3649,6 +3633,42 @@
             "additionalProperties": false
           }
         ]
+      },
+      "ExecutionInfo": {
+        "description": "The block hash and height in which a given deploy was executed, along with the execution result if known.",
+        "type": "object",
+        "required": [
+          "block_hash",
+          "block_height"
+        ],
+        "properties": {
+          "block_hash": {
+            "description": "The hash of the block in which the deploy was executed.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BlockHash"
+              }
+            ]
+          },
+          "block_height": {
+            "description": "The height of the block in which the deploy was executed.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "execution_result": {
+            "description": "The execution result if known.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ExecutionResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
       },
       "BlockHash": {
         "description": "Hex-encoded cryptographic hash of a block.",

--- a/rpc_sidecar/src/lib.rs
+++ b/rpc_sidecar/src/lib.rs
@@ -121,6 +121,7 @@ mod tests {
     use std::fs;
 
     use assert_json_diff::{assert_json_eq, assert_json_matches_no_panic, CompareMode, Config};
+    use casper_types::bytesrepr::ToBytes;
     use regex::Regex;
     use serde_json::Value;
     use std::io::Write;

--- a/rpc_sidecar/src/lib.rs
+++ b/rpc_sidecar/src/lib.rs
@@ -121,7 +121,6 @@ mod tests {
     use std::fs;
 
     use assert_json_diff::{assert_json_eq, assert_json_matches_no_panic, CompareMode, Config};
-    use casper_types::bytesrepr::ToBytes;
     use regex::Regex;
     use serde_json::Value;
     use std::io::Write;

--- a/rpc_sidecar/src/rpcs/info.rs
+++ b/rpc_sidecar/src/rpcs/info.rs
@@ -127,7 +127,6 @@ pub struct GetDeployResult {
     /// The deploy.
     pub deploy: Deploy,
     /// Execution info, if available.
-    #[serde(skip_serializing_if = "Option::is_none", flatten)]
     pub execution_info: Option<ExecutionInfo>,
 }
 
@@ -200,7 +199,6 @@ pub struct GetTransactionResult {
     /// The transaction.
     pub transaction: Transaction,
     /// Execution info, if available.
-    #[serde(skip_serializing_if = "Option::is_none", flatten)]
     pub execution_info: Option<ExecutionInfo>,
 }
 
@@ -539,6 +537,36 @@ mod tests {
     use rand::Rng;
 
     use super::*;
+
+    #[tokio::test]
+    async fn get_deploy_result_none_execution_info_should_serialize_to_null() {
+        let rng = &mut TestRng::new();
+        let deploy = Deploy::random(rng);
+        let result = GetDeployResult {
+            api_version: CURRENT_API_VERSION,
+            deploy,
+            execution_info: None,
+        };
+
+        let json_value = serde_json::to_value(&result).unwrap();
+
+        assert!(json_value.get("execution_info").unwrap().is_null());
+    }
+
+    #[tokio::test]
+    async fn get_transaction_result_none_execution_info_should_serialize_to_null() {
+        let rng = &mut TestRng::new();
+        let transaction = Transaction::random(rng);
+        let result = GetTransactionResult {
+            api_version: CURRENT_API_VERSION,
+            transaction,
+            execution_info: None,
+        };
+
+        let json_value = serde_json::to_value(&result).unwrap();
+
+        assert!(json_value.get("execution_info").unwrap().is_null());
+    }
 
     #[tokio::test]
     async fn should_read_transaction() {

--- a/rpc_sidecar/src/rpcs/info.rs
+++ b/rpc_sidecar/src/rpcs/info.rs
@@ -550,7 +550,7 @@ mod tests {
 
         let json_value = serde_json::to_value(&result).unwrap();
 
-        assert!(json_value.get("execution_info").unwrap().is_null());
+        assert!(json_value.get("execution_info").expect("should have execution_info").is_null());
     }
 
     #[tokio::test]
@@ -565,7 +565,7 @@ mod tests {
 
         let json_value = serde_json::to_value(&result).unwrap();
 
-        assert!(json_value.get("execution_info").unwrap().is_null());
+        assert!(json_value.get("execution_info").expect("should have execution_info").is_null());
     }
 
     #[tokio::test]

--- a/rpc_sidecar/src/rpcs/info.rs
+++ b/rpc_sidecar/src/rpcs/info.rs
@@ -550,7 +550,10 @@ mod tests {
 
         let json_value = serde_json::to_value(&result).unwrap();
 
-        assert!(json_value.get("execution_info").expect("should have execution_info").is_null());
+        assert!(json_value
+            .get("execution_info")
+            .expect("should have execution_info")
+            .is_null());
     }
 
     #[tokio::test]
@@ -565,7 +568,10 @@ mod tests {
 
         let json_value = serde_json::to_value(&result).unwrap();
 
-        assert!(json_value.get("execution_info").expect("should have execution_info").is_null());
+        assert!(json_value
+            .get("execution_info")
+            .expect("should have execution_info")
+            .is_null());
     }
 
     #[tokio::test]


### PR DESCRIPTION
To make the json RPC more consistent all occurrences of `skip_serializing_if` for Option type were removed. As a general rule we return 'null' for None and the three exceptions from json RPC are inconsistencies.
List of fields that were of type `Option<...>` and had `skip_serializing_if`:
* GetTransactionResult::execution_info
* GetDeployResult::execution_info
* Error::data (in json_rpc submodule)