### PR TITLE
Remove 'juliet' from the RPC sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#b2b2fba996218845ff99467f8d97a95d3e5a621c"
 dependencies = [
  "bincode",
+ "bytes",
  "casper-types",
  "once_cell",
  "rand",
@@ -517,6 +517,7 @@ dependencies = [
  "serde",
  "serde-map-to-array",
  "thiserror",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -542,7 +543,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.10",
  "tracing",
  "url",
  "warp",
@@ -590,7 +591,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.10",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -669,6 +670,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util 0.6.10",
  "toml",
  "tower",
  "tracing",
@@ -704,7 +706,6 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#b2b2fba996218845ff99467f8d97a95d3e5a621c"
 dependencies = [
  "base16",
  "base64 0.13.1",
@@ -2104,7 +2105,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.10",
  "tracing",
 ]
 
@@ -3509,7 +3510,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
+ "tokio-util 0.7.10",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4712,7 +4713,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.10",
 ]
 
 [[package]]
@@ -4725,6 +4726,20 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4760,7 +4775,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.10",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5161,7 +5176,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util",
+ "tokio-util 0.7.10",
  "tower-service",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
+source = "git+https://github.com/rafal-ch/casper-node?branch=julietless_node_2#33415a5a0b26757ac21ce62a457d8481940904e1"
 dependencies = [
  "bincode",
  "bytes",
@@ -665,6 +666,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
+source = "git+https://github.com/rafal-ch/casper-node?branch=julietless_node_2#33415a5a0b26757ac21ce62a457d8481940904e1"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ toml = "0.5.8"
 tracing = { version = "0", default-features = false }
 tracing-subscriber = "0"
 serde = { version = "1", default-features = false }
+
+[patch."https://github.com/casper-network/casper-node"]
+casper-binary-port = { path = "../casper-node/binary_port" }
+casper-types = { path = "../casper-node/types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [
 anyhow = "1"
 async-stream = "0.3.4"
 async-trait = "0.1.77"
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "feat-2.0" }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch = "feat-2.0" }
+casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "julietless_node_2" }
+casper-binary-port = { git = "https://github.com/rafal-ch/casper-node", branch = "julietless_node_2" }
 casper-event-sidecar = { path = "./event_sidecar", version = "1.0.0" }
 casper-event-types = { path = "./types", version = "1.0.0" }
 casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }
@@ -30,7 +30,3 @@ toml = "0.5.8"
 tracing = { version = "0", default-features = false }
 tracing-subscriber = "0"
 serde = { version = "1", default-features = false }
-
-[patch."https://github.com/casper-network/casper-node"]
-casper-binary-port = { path = "../casper-node/binary_port" }
-casper-types = { path = "../casper-node/types" }

--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ cors_origin = ''
 
 [rpc_server.node_client]
 address = '127.0.0.1:28101'
-max_request_size_bytes = 4_194_304
-max_response_size_bytes = 4_194_304
+max_message_size_bytes = 4_194_304
 request_limit = 3
 request_buffer_size = 16
 
@@ -171,8 +170,7 @@ max_attempts = 30
 * `speculative_exec_server.cors_origin` - Configures the CORS origin.
 
 * `node_client.address` - Address of the Casper Node binary port
-* `node_client.max_request_size_bytes` - Maximum request size to the binary port in bytes.
-* `node_client.max_response_size_bytes` - Maximum response size from the binary port in bytes.
+* `node_client.max_message_size_bytes` - Maximum binary port message size in bytes.
 * `node_client.request_limit` - Maximum number of in-flight requests.
 * `node_client.request_buffer_size` - Number of node requests that can be buffered.
 

--- a/resources/example_configs/default_rpc_only_config.toml
+++ b/resources/example_configs/default_rpc_only_config.toml
@@ -72,6 +72,8 @@ max_message_size_bytes = 4_194_304
 request_limit = 3
 # Number of node requests that can be buffered.
 request_buffer_size = 16
+# Timeout for a node request in seconds.
+message_timeout_secs = 30
 
 [rpc_server.node_client.exponential_backoff]
 # The initial delay in milliseconds before the first retry.

--- a/resources/example_configs/default_rpc_only_config.toml
+++ b/resources/example_configs/default_rpc_only_config.toml
@@ -66,10 +66,8 @@ cors_origin = ''
 [rpc_server.node_client]
 # The address of the node to connect to.
 address = '127.0.0.1:28104'
-# Maximum size of a request in bytes.
-max_request_size_bytes = 4_194_304
-# Maximum size of a response in bytes.
-max_response_size_bytes = 4_194_304
+# Maximum size of a message in bytes.
+max_message_size_bytes = 4_194_304
 # Maximum number of in-flight node requests.
 request_limit = 3
 # Number of node requests that can be buffered.

--- a/resources/example_configs/default_rpc_only_config.toml
+++ b/resources/example_configs/default_rpc_only_config.toml
@@ -74,6 +74,8 @@ request_limit = 3
 request_buffer_size = 16
 # Timeout for a node request in seconds.
 message_timeout_secs = 30
+# Timeout specifying how long to wait for binary port client to be available.
+client_access_timeout_secs = 2
 
 [rpc_server.node_client.exponential_backoff]
 # The initial delay in milliseconds before the first retry.

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -412,6 +412,7 @@
                       }
                     }
                   ],
+                  "size_estimate": 186,
                   "effects": [
                     {
                       "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
@@ -617,6 +618,7 @@
                       }
                     }
                   ],
+                  "size_estimate": 186,
                   "effects": [
                     {
                       "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
@@ -4846,6 +4848,7 @@
           "initiator",
           "limit",
           "payment",
+          "size_estimate",
           "transfers"
         ],
         "properties": {
@@ -4901,6 +4904,12 @@
             "items": {
               "$ref": "#/components/schemas/Transfer"
             }
+          },
+          "size_estimate": {
+            "description": "The size estimate of the transaction",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           },
           "effects": {
             "description": "The effects of executing this transaction.",
@@ -5784,11 +5793,10 @@
           },
           "versions": {
             "description": "All versions (enabled & disabled)",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Array_of_ContractVersionAndHash"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContractVersion"
+            }
           },
           "disabled_versions": {
             "description": "Disabled versions",
@@ -5816,34 +5824,32 @@
           }
         }
       },
-      "Array_of_ContractVersionAndHash": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/ContractVersionAndHash"
-        }
-      },
-      "ContractVersionAndHash": {
+      "ContractVersion": {
         "type": "object",
         "required": [
-          "contract_entity_hash",
-          "contract_version_key"
+          "contract_hash",
+          "contract_version",
+          "protocol_version_major"
         ],
         "properties": {
-          "contract_version_key": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ContractVersionKey"
-              }
-            ]
+          "protocol_version_major": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
           },
-          "contract_entity_hash": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ContractHash"
-              }
-            ]
+          "contract_version": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "contract_hash": {
+            "$ref": "#/components/schemas/ContractHash"
           }
         }
+      },
+      "ContractHash": {
+        "description": "The hash address of the contract",
+        "type": "string"
       },
       "ContractVersionKey": {
         "description": "Major element of `ProtocolVersion` combined with `ContractVersion`.",
@@ -5862,10 +5868,6 @@
         ],
         "maxItems": 2,
         "minItems": 2
-      },
-      "ContractHash": {
-        "description": "The hash address of the contract",
-        "type": "string"
       },
       "Array_of_NamedUserGroup": {
         "type": "array",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -3194,9 +3194,7 @@
               "Reserved": {
                 "type": "object",
                 "required": [
-                  "paid_amount",
-                  "receipt",
-                  "strike_price"
+                  "receipt"
                 ],
                 "properties": {
                   "receipt": {
@@ -3206,18 +3204,6 @@
                         "$ref": "#/components/schemas/Digest"
                       }
                     ]
-                  },
-                  "paid_amount": {
-                    "description": "Price paid in the past to reserve space in a future block.",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "strike_price": {
-                    "description": "The gas price at the time of reservation.",
-                    "type": "integer",
-                    "format": "uint8",
-                    "minimum": 0.0
                   }
                 },
                 "additionalProperties": false
@@ -5464,6 +5450,19 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "A reservation record.",
+            "type": "object",
+            "required": [
+              "Reservation"
+            ],
+            "properties": {
+              "Reservation": {
+                "$ref": "#/components/schemas/ReservationKind"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -6328,6 +6327,28 @@
                 "$ref": "#/components/schemas/CLValue"
               }
             ]
+          }
+        }
+      },
+      "ReservationKind": {
+        "description": "Container for bytes recording location, type and data for a gas reservation",
+        "type": "object",
+        "required": [
+          "receipt",
+          "reservation_data",
+          "reservation_kind"
+        ],
+        "properties": {
+          "receipt": {
+            "$ref": "#/components/schemas/Digest"
+          },
+          "reservation_kind": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "reservation_data": {
+            "$ref": "#/components/schemas/Bytes"
           }
         }
       },

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -1713,6 +1713,19 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "A reservation record.",
+            "type": "object",
+            "required": [
+              "Reservation"
+            ],
+            "properties": {
+              "Reservation": {
+                "$ref": "#/components/schemas/ReservationKind"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -3150,6 +3163,28 @@
           }
         }
       },
+      "ReservationKind": {
+        "description": "Container for bytes recording location, type and data for a gas reservation",
+        "type": "object",
+        "required": [
+          "receipt",
+          "reservation_data",
+          "reservation_kind"
+        ],
+        "properties": {
+          "receipt": {
+            "$ref": "#/components/schemas/Digest"
+          },
+          "reservation_kind": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "reservation_data": {
+            "$ref": "#/components/schemas/Bytes"
+          }
+        }
+      },
       "U128": {
         "description": "Decimal representation of a 128-bit integer.",
         "type": "string"
@@ -3531,9 +3566,7 @@
               "Reserved": {
                 "type": "object",
                 "required": [
-                  "paid_amount",
-                  "receipt",
-                  "strike_price"
+                  "receipt"
                 ],
                 "properties": {
                   "receipt": {
@@ -3543,18 +3576,6 @@
                         "$ref": "#/components/schemas/Digest"
                       }
                     ]
-                  },
-                  "paid_amount": {
-                    "description": "Price paid in the past to reserve space in a future block.",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "strike_price": {
-                    "description": "The gas price at the time of reservation.",
-                    "type": "integer",
-                    "format": "uint8",
-                    "minimum": 0.0
                   }
                 },
                 "additionalProperties": false

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -2070,11 +2070,10 @@
           },
           "versions": {
             "description": "All versions (enabled & disabled)",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Array_of_ContractVersionAndHash"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContractVersion"
+            }
           },
           "disabled_versions": {
             "description": "Disabled versions",
@@ -2102,34 +2101,32 @@
           }
         }
       },
-      "Array_of_ContractVersionAndHash": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/ContractVersionAndHash"
-        }
-      },
-      "ContractVersionAndHash": {
+      "ContractVersion": {
         "type": "object",
         "required": [
-          "contract_entity_hash",
-          "contract_version_key"
+          "contract_hash",
+          "contract_version",
+          "protocol_version_major"
         ],
         "properties": {
-          "contract_version_key": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ContractVersionKey"
-              }
-            ]
+          "protocol_version_major": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
           },
-          "contract_entity_hash": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ContractHash"
-              }
-            ]
+          "contract_version": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "contract_hash": {
+            "$ref": "#/components/schemas/ContractHash"
           }
         }
+      },
+      "ContractHash": {
+        "description": "The hash address of the contract",
+        "type": "string"
       },
       "ContractVersionKey": {
         "description": "Major element of `ProtocolVersion` combined with `ContractVersion`.",
@@ -2148,10 +2145,6 @@
         ],
         "maxItems": 2,
         "minItems": 2
-      },
-      "ContractHash": {
-        "description": "The hash address of the contract",
-        "type": "string"
       },
       "Array_of_NamedUserGroup": {
         "type": "array",

--- a/rpc_sidecar/Cargo.toml
+++ b/rpc_sidecar/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 structopt = "0.3.14"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-util = { version = "0.6.4", features = ["codec"] }
 toml = { workspace = true }
 tower = { version = "0.4.6", features = ["limit"] }
 tracing = { workspace = true, default-features = true }

--- a/rpc_sidecar/src/config.rs
+++ b/rpc_sidecar/src/config.rs
@@ -106,7 +106,7 @@ impl Default for RpcConfig {
 // Change this to SocketAddr, once SocketAddr::new is const stable.
 const DEFAULT_NODE_CONNECT_ADDRESS: (IpAddr, u16) = (IpAddr::V4(Ipv4Addr::LOCALHOST), 28104);
 /// Default maximum payload size.
-const DEFAULT_MAX_NODE_PAYLOAD_SIZE: u32 = 4 * 1024 * 1024;
+const DEFAULT_MAX_PAYLOAD_SIZE: u32 = 4 * 1024 * 1024;
 /// Default request limit.
 const DEFAULT_NODE_REQUEST_LIMIT: u16 = 3;
 /// Default request buffer size.
@@ -125,10 +125,8 @@ const DEFAULT_EXPONENTIAL_BACKOFF_COEFFICIENT: u64 = 2;
 pub struct NodeClientConfig {
     /// Address of the node.
     pub address: SocketAddr,
-    /// Maximum size of a request in bytes.
-    pub max_request_size_bytes: u32,
-    /// Maximum size of a response in bytes.
-    pub max_response_size_bytes: u32,
+    /// Maximum size of a message in bytes.
+    pub max_message_size_bytes: u32,
     /// Maximum number of in-flight node requests.
     pub request_limit: u16,
     /// Number of node requests that can be buffered.
@@ -143,8 +141,7 @@ impl NodeClientConfig {
         NodeClientConfig {
             address: DEFAULT_NODE_CONNECT_ADDRESS.into(),
             request_limit: DEFAULT_NODE_REQUEST_LIMIT,
-            max_request_size_bytes: DEFAULT_MAX_NODE_PAYLOAD_SIZE,
-            max_response_size_bytes: DEFAULT_MAX_NODE_PAYLOAD_SIZE,
+            max_message_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE,
             request_buffer_size: DEFAULT_REQUEST_BUFFER_SIZE,
             exponential_backoff: ExponentialBackoffConfig {
                 initial_delay_ms: DEFAULT_EXPONENTIAL_BACKOFF_BASE_MS,
@@ -161,8 +158,7 @@ impl NodeClientConfig {
         NodeClientConfig {
             address: local_socket,
             request_limit: DEFAULT_NODE_REQUEST_LIMIT,
-            max_request_size_bytes: DEFAULT_MAX_NODE_PAYLOAD_SIZE,
-            max_response_size_bytes: DEFAULT_MAX_NODE_PAYLOAD_SIZE,
+            max_message_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE,
             request_buffer_size: DEFAULT_REQUEST_BUFFER_SIZE,
             exponential_backoff: ExponentialBackoffConfig {
                 initial_delay_ms: 500,
@@ -187,10 +183,8 @@ impl Default for NodeClientConfig {
 pub struct NodeClientConfigTarget {
     /// Address of the node.
     pub address: SocketAddr,
-    /// Maximum size of a request in bytes.
-    pub max_request_size_bytes: u32,
-    /// Maximum size of a response in bytes.
-    pub max_response_size_bytes: u32,
+    /// Maximum size of a message in bytes.
+    pub max_message_size_bytes: u32,
     /// Maximum number of in-flight node requests.
     pub request_limit: u16,
     /// Number of node requests that can be buffered.
@@ -213,8 +207,7 @@ impl TryFrom<NodeClientConfigTarget> for NodeClientConfig {
         Ok(NodeClientConfig {
             address: value.address,
             request_limit: value.request_limit,
-            max_request_size_bytes: value.max_request_size_bytes,
-            max_response_size_bytes: value.max_response_size_bytes,
+            max_message_size_bytes: value.max_message_size_bytes,
             request_buffer_size: value.request_buffer_size,
             exponential_backoff,
         })

--- a/rpc_sidecar/src/config.rs
+++ b/rpc_sidecar/src/config.rs
@@ -109,6 +109,8 @@ const DEFAULT_NODE_CONNECT_ADDRESS: (IpAddr, u16) = (IpAddr::V4(Ipv4Addr::LOCALH
 const DEFAULT_MAX_PAYLOAD_SIZE: u32 = 4 * 1024 * 1024;
 /// Default message timeout in seconds.
 const DEFAULT_MESSAGE_TIMEOUT_SECS: u64 = 30;
+/// Default timeout for client access.
+const DEFAULT_CLIENT_ACCESS_TIMEOUT_SECS: u64 = 10;
 /// Default request limit.
 const DEFAULT_NODE_REQUEST_LIMIT: u16 = 3;
 /// Default request buffer size.
@@ -131,6 +133,9 @@ pub struct NodeClientConfig {
     pub max_message_size_bytes: u32,
     /// Message transfer timeout in seconds.
     pub message_timeout_secs: u64,
+    /// Timeout specifying how long to wait for binary port client to be available.
+    // Access to the client is synchronized.
+    pub client_access_timeout_secs: u64,
     /// Maximum number of in-flight node requests.
     pub request_limit: u16,
     /// Number of node requests that can be buffered.
@@ -148,6 +153,7 @@ impl NodeClientConfig {
             max_message_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE,
             request_buffer_size: DEFAULT_REQUEST_BUFFER_SIZE,
             message_timeout_secs: DEFAULT_MESSAGE_TIMEOUT_SECS,
+            client_access_timeout_secs: DEFAULT_CLIENT_ACCESS_TIMEOUT_SECS,
             exponential_backoff: ExponentialBackoffConfig {
                 initial_delay_ms: DEFAULT_EXPONENTIAL_BACKOFF_BASE_MS,
                 max_delay_ms: DEFAULT_EXPONENTIAL_BACKOFF_MAX_MS,
@@ -166,6 +172,7 @@ impl NodeClientConfig {
             max_message_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE,
             request_buffer_size: DEFAULT_REQUEST_BUFFER_SIZE,
             message_timeout_secs: DEFAULT_MESSAGE_TIMEOUT_SECS,
+            client_access_timeout_secs: DEFAULT_CLIENT_ACCESS_TIMEOUT_SECS,
             exponential_backoff: ExponentialBackoffConfig {
                 initial_delay_ms: 500,
                 max_delay_ms: 3000,
@@ -193,6 +200,9 @@ pub struct NodeClientConfigTarget {
     pub max_message_size_bytes: u32,
     /// Message transfer timeout in seconds.
     pub message_timeout_secs: u64,
+    /// Timeout specifying how long to wait for binary port client to be available.
+    // Access to the client is synchronized.
+    pub client_access_timeout_secs: u64,
     /// Maximum number of in-flight node requests.
     pub request_limit: u16,
     /// Number of node requests that can be buffered.
@@ -217,6 +227,7 @@ impl TryFrom<NodeClientConfigTarget> for NodeClientConfig {
             request_limit: value.request_limit,
             max_message_size_bytes: value.max_message_size_bytes,
             request_buffer_size: value.request_buffer_size,
+            client_access_timeout_secs: value.client_access_timeout_secs,
             message_timeout_secs: value.message_timeout_secs,
             exponential_backoff,
         })

--- a/rpc_sidecar/src/config.rs
+++ b/rpc_sidecar/src/config.rs
@@ -107,6 +107,8 @@ impl Default for RpcConfig {
 const DEFAULT_NODE_CONNECT_ADDRESS: (IpAddr, u16) = (IpAddr::V4(Ipv4Addr::LOCALHOST), 28104);
 /// Default maximum payload size.
 const DEFAULT_MAX_PAYLOAD_SIZE: u32 = 4 * 1024 * 1024;
+/// Default message timeout in seconds.
+const DEFAULT_MESSAGE_TIMEOUT_SECS: u64 = 30;
 /// Default request limit.
 const DEFAULT_NODE_REQUEST_LIMIT: u16 = 3;
 /// Default request buffer size.
@@ -127,6 +129,8 @@ pub struct NodeClientConfig {
     pub address: SocketAddr,
     /// Maximum size of a message in bytes.
     pub max_message_size_bytes: u32,
+    /// Message transfer timeout in seconds.
+    pub message_timeout_secs: u64,
     /// Maximum number of in-flight node requests.
     pub request_limit: u16,
     /// Number of node requests that can be buffered.
@@ -143,6 +147,7 @@ impl NodeClientConfig {
             request_limit: DEFAULT_NODE_REQUEST_LIMIT,
             max_message_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE,
             request_buffer_size: DEFAULT_REQUEST_BUFFER_SIZE,
+            message_timeout_secs: DEFAULT_MESSAGE_TIMEOUT_SECS,
             exponential_backoff: ExponentialBackoffConfig {
                 initial_delay_ms: DEFAULT_EXPONENTIAL_BACKOFF_BASE_MS,
                 max_delay_ms: DEFAULT_EXPONENTIAL_BACKOFF_MAX_MS,
@@ -160,6 +165,7 @@ impl NodeClientConfig {
             request_limit: DEFAULT_NODE_REQUEST_LIMIT,
             max_message_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE,
             request_buffer_size: DEFAULT_REQUEST_BUFFER_SIZE,
+            message_timeout_secs: DEFAULT_MESSAGE_TIMEOUT_SECS,
             exponential_backoff: ExponentialBackoffConfig {
                 initial_delay_ms: 500,
                 max_delay_ms: 3000,
@@ -185,6 +191,8 @@ pub struct NodeClientConfigTarget {
     pub address: SocketAddr,
     /// Maximum size of a message in bytes.
     pub max_message_size_bytes: u32,
+    /// Message transfer timeout in seconds.
+    pub message_timeout_secs: u64,
     /// Maximum number of in-flight node requests.
     pub request_limit: u16,
     /// Number of node requests that can be buffered.
@@ -209,6 +217,7 @@ impl TryFrom<NodeClientConfigTarget> for NodeClientConfig {
             request_limit: value.request_limit,
             max_message_size_bytes: value.max_message_size_bytes,
             request_buffer_size: value.request_buffer_size,
+            message_timeout_secs: value.message_timeout_secs,
             exponential_backoff,
         })
     }

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -448,8 +448,10 @@ impl NodeClient for FramedNodeClient {
             .await
             .map_err(|err| Error::RequestFailed(err.to_string()))?;
 
+        // TODO: Use queue instead of individual timeouts. Currently it is possible to go pass the
+        // semaphore and the immediately wait for the client to become available.
         let mut client = match tokio::time::timeout(
-            Duration::from_secs(self.config.message_timeout_secs),
+            Duration::from_secs(self.config.client_access_timeout_secs),
             self.client.write(),
         )
         .await

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -594,7 +594,7 @@ mod tests {
     #[tokio::test]
     async fn given_client_and_no_node_should_fail_after_tries() {
         let config = NodeClientConfig::finite_retries_config(1111, 2);
-        let res = JulietNodeClient::new(config).await;
+        let res = FramedNodeClient::new(config).await;
 
         assert!(res.is_err());
         let error_message = res.err().unwrap().to_string();
@@ -609,10 +609,7 @@ mod tests {
         let mut rng = TestRng::new();
         let _mock_server_handle = start_mock_binary_port_responding_with_stored_value(port).await;
         let config = NodeClientConfig::finite_retries_config(port, 2);
-        let (c, server_loop) = JulietNodeClient::new(config).await.unwrap();
-        tokio::spawn(async move {
-            server_loop.await.unwrap();
-        });
+        let c = FramedNodeClient::new(config).await.unwrap();
 
         let res = query_global_state_for_string_value(&mut rng, &c)
             .await
@@ -631,10 +628,7 @@ mod tests {
                 start_mock_binary_port_responding_with_stored_value(port).await;
         });
         let config = NodeClientConfig::finite_retries_config(port, 5);
-        let (client, server_loop) = JulietNodeClient::new(config).await.unwrap();
-        tokio::spawn(async move {
-            server_loop.await.unwrap();
-        });
+        let client = FramedNodeClient::new(config).await.unwrap();
 
         let res = query_global_state_for_string_value(&mut rng, &client)
             .await
@@ -645,7 +639,7 @@ mod tests {
 
     async fn query_global_state_for_string_value(
         rng: &mut TestRng,
-        client: &JulietNodeClient,
+        client: &FramedNodeClient,
     ) -> Result<StoredValue, Error> {
         let state_root_hash = Digest::random(rng);
         let base_key = Key::ChecksumRegistry;

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -1,4 +1,4 @@
-use crate::{config::ExponentialBackoffConfig, NodeClientConfig, SUPPORTED_PROTOCOL_VERSION};
+use crate::{NodeClientConfig, SUPPORTED_PROTOCOL_VERSION};
 use anyhow::Error as AnyhowError;
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
@@ -6,8 +6,6 @@ use metrics::rpc::{inc_disconnect, observe_reconnect_time};
 use serde::de::DeserializeOwned;
 use std::{
     convert::{TryFrom, TryInto},
-    future::Future,
-    net::SocketAddr,
     sync::Arc,
     time::Duration,
 };
@@ -31,10 +29,7 @@ use std::{
     time::Instant,
 };
 use tokio::{
-    net::{
-        tcp::{OwnedReadHalf, OwnedWriteHalf},
-        TcpStream,
-    },
+    net::TcpStream,
     sync::{Notify, RwLock},
 };
 use tracing::{error, field, info, warn};

--- a/rpc_sidecar/src/testing/mod.rs
+++ b/rpc_sidecar/src/testing/mod.rs
@@ -93,7 +93,6 @@ async fn start_mock_binary_port(port: u16, data: Vec<u8>) -> JoinHandle<()> {
         let binary_port = BinaryPortMock::new(port, data);
         binary_port.start().await;
     });
-    sleep(Duration::from_secs(3)).await; // This should be handled differently, preferrably the mock binary port should inform that it already bound to the port
+    sleep(Duration::from_secs(3)).await; // This should be handled differently, preferably the mock binary port should inform that it already bound to the port
     handler
 }
-*/

--- a/rpc_sidecar/src/testing/mod.rs
+++ b/rpc_sidecar/src/testing/mod.rs
@@ -3,12 +3,6 @@ use std::time::Duration;
 use bytes::{BufMut, BytesMut};
 use casper_binary_port::{BinaryResponse, BinaryResponseAndRequest, GlobalStateQueryResult};
 use casper_types::{bytesrepr::ToBytes, CLValue, ProtocolVersion, StoredValue};
-use juliet::{
-    io::IoCoreBuilder,
-    protocol::ProtocolBuilder,
-    rpc::{IncomingRequest, RpcBuilder},
-    ChannelConfiguration, ChannelId,
-};
 use tokio::task::JoinHandle;
 use tokio::{
     net::{TcpListener, TcpStream},
@@ -17,6 +11,7 @@ use tokio::{
 
 const LOCALHOST: &str = "127.0.0.1";
 
+/*
 pub struct BinaryPortMock {
     port: u16,
     response: Vec<u8>,
@@ -101,3 +96,4 @@ async fn start_mock_binary_port(port: u16, data: Vec<u8>) -> JoinHandle<()> {
     sleep(Duration::from_secs(3)).await; // This should be handled differently, preferrably the mock binary port should inform that it already bound to the port
     handler
 }
+*/

--- a/rpc_sidecar/src/testing/mod.rs
+++ b/rpc_sidecar/src/testing/mod.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use bytes::{BufMut, BytesMut};
 use casper_binary_port::{
     BinaryMessage, BinaryMessageCodec, BinaryResponse, BinaryResponseAndRequest,
     GlobalStateQueryResult,
@@ -51,7 +50,7 @@ async fn handle_client(stream: TcpStream, response: Vec<u8>) {
     let mut client = Framed::new(stream, BinaryMessageCodec::new(MESSAGE_SIZE));
 
     let next_message = client.next().await;
-    if let Some(_) = next_message {
+    if next_message.is_some() {
         tokio::spawn({
             async move {
                 let _ = client.send(BinaryMessage::new(response)).await;


### PR DESCRIPTION
This PR changes the communication method of the binary port from 'juliet' to tokio framed transport.

The corresponding PR on the node side: [PR](https://github.com/casper-network/casper-node/pull/4678).