### PR TITLE
Mapping for legacy filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,47 +93,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -244,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
@@ -467,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#897332af35f0fcfa78489c23df56f8402e1bb745"
+source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#73178683865ec0353a9bbae50b1ef1e81bf07f1f"
 dependencies = [
  "bincode",
  "bytes",
@@ -504,7 +505,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.11",
  "tracing",
  "url",
  "warp",
@@ -552,7 +553,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.11",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -571,7 +572,10 @@ dependencies = [
  "casper-types",
  "hex-buffer-serde",
  "hex_fmt",
+ "itertools 0.10.5",
+ "mockall",
  "once_cell",
+ "pretty_assertions",
  "rand",
  "serde",
  "serde_json",
@@ -666,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#897332af35f0fcfa78489c23df56f8402e1bb745"
+source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#73178683865ec0353a9bbae50b1ef1e81bf07f1f"
 dependencies = [
  "base16",
  "base64 0.13.1",
@@ -709,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 dependencies = [
  "jobserver",
  "libc",
@@ -776,15 +780,15 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clru"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807"
+checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
@@ -1091,6 +1095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1374,12 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -1737,7 +1753,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix 0.38.34",
+ "rustix",
  "smallvec",
  "thiserror",
 ]
@@ -2021,7 +2037,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.11",
  "tracing",
 ]
 
@@ -2285,21 +2301,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "iso8601"
@@ -2423,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libm"
@@ -2453,12 +2464,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2575,6 +2580,33 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2737,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2761,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -3062,6 +3094,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,15 +3173,25 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.14.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.5.0",
  "hex",
  "lazy_static",
- "rustix 0.36.17",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.5.0",
+ "hex",
 ]
 
 [[package]]
@@ -3134,9 +3202,9 @@ checksum = "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79"
 
 [[package]]
 name = "prometheus"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -3363,7 +3431,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3469,20 +3537,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
@@ -3490,7 +3544,7 @@ dependencies = [
  "bitflags 2.5.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -3651,11 +3705,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3664,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3680,9 +3734,9 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
@@ -3708,9 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -4260,9 +4314,15 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix 0.38.34",
+ "rustix",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
@@ -4411,7 +4471,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.11",
 ]
 
 [[package]]
@@ -4442,16 +4502,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4473,7 +4532,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.11",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4718,9 +4777,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utoipa"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272ebdfbc99111033031d2f10e018836056e4d2c8e2acda76450ec7974269fa7"
+checksum = "e95b8d4503ee98939fb7024f6da083f7c48ff033cc3cba7521360e1bc6c1470b"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -4730,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c9f4d08338c1bfa70dde39412a040a884c6f318b3d09aaaf3437a1e52027fc"
+checksum = "7bf0e16c02bc4bf5322ab65f10ab1149bdbcaa782cba66dc7057370a3f8190be"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.81",
@@ -4866,7 +4925,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-tungstenite",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.11",
  "tower-service",
  "tracing",
 ]
@@ -5027,15 +5086,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5050,21 +5100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5100,12 +5135,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5118,12 +5147,6 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5133,12 +5156,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5160,12 +5177,6 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5175,12 +5186,6 @@ name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5196,12 +5201,6 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5211,12 +5210,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5256,8 +5249,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys 0.4.13",
- "rustix 0.38.34",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]
@@ -5277,18 +5270,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "087eca3c1eaf8c47b94d02790dd086cd594b912d2043d4de4bfdd466b3befb7c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "6f4b6c273f496d8fd4eaf18853e6b448760225dc030ff2c485a786859aea6393"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }
 datasize = "0.2.11"
 futures = "0"
 futures-util = "0.3.28"
+itertools = "0.10.3"
 metrics = { path = "./metrics", version = "1.0.0" }
 once_cell = "1.18.0"
 thiserror = "1"

--- a/event_sidecar/Cargo.toml
+++ b/event_sidecar/Cargo.toml
@@ -29,7 +29,7 @@ hex_fmt = "0.3.0"
 http = "0.2.1"
 hyper = "0.14.4"
 indexmap = "2.0.0"
-itertools = "0.10.3"
+itertools = { workspace = true }
 jsonschema = "0.17.1"
 metrics = { workspace = true }
 pin-project = "1.1.5"

--- a/event_sidecar/src/lib.rs
+++ b/event_sidecar/src/lib.rs
@@ -777,5 +777,5 @@ async fn start_single_threaded_events_consumer<
 }
 
 fn count_error(reason: &str) {
-    observe_error("main_loop", reason);
+    observe_error("event_listener_server", reason);
 }

--- a/event_sidecar/src/testing/mock_node.rs
+++ b/event_sidecar/src/testing/mock_node.rs
@@ -48,6 +48,22 @@ pub mod tests {
             )
         }
 
+        pub fn build_example_2_0_0_node_with_data(
+            node_port_for_sse_connection: u16,
+            node_port_for_rest_connection: u16,
+            data: EventsWithIds,
+        ) -> MockNode {
+            MockNodeBuilder {
+                version: "2.0.0".to_string(),
+                network_name: "network-1".to_string(),
+                data_of_node: data,
+                cache_of_node: None,
+                sse_port: Some(node_port_for_sse_connection),
+                rest_port: Some(node_port_for_rest_connection),
+            }
+            .build()
+        }
+
         pub fn build_example_node_with_version(
             node_port_for_sse_connection: Option<u16>,
             node_port_for_rest_connection: Option<u16>,

--- a/event_sidecar/src/testing/raw_sse_events_utils.rs
+++ b/event_sidecar/src/testing/raw_sse_events_utils.rs
@@ -65,6 +65,16 @@ pub(crate) mod tests {
         ]
     }
 
+    pub fn sse_server_sigs_2_0_0_data() -> EventsWithIds {
+        vec![
+            (None, "{\"ApiVersion\":\"2.0.0\"}".to_string()),
+            (
+                Some("1".to_string()),
+                example_finality_signature_2_0_0(BLOCK_HASH_2),
+            ),
+        ]
+    }
+
     pub fn sse_server_example_2_0_0_data_second() -> EventsWithIds {
         vec![
             (None, "{\"ApiVersion\":\"2.0.0\"}".to_string()),

--- a/json_rpc/Cargo.toml
+++ b/json_rpc/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 bytes = "1.1.0"
 futures = { workspace = true }
 http = "0.2.7"
-itertools = "0.10.3"
+itertools = { workspace = true }
 metrics = { workspace = true }
 serde = { workspace = true, default-features = true, features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -3554,6 +3554,13 @@
             "enum": [
               "ActivateBid"
             ]
+          },
+          {
+            "description": "The `change_bid_public_key` native entry point, used to change a bid's public key.",
+            "type": "string",
+            "enum": [
+              "ChangeBidPublicKey"
+            ]
           }
         ]
       },
@@ -4794,6 +4801,19 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "A bridge record pointing to a new `ValidatorBid` after the public key was changed.",
+            "type": "object",
+            "required": [
+              "Bridge"
+            ],
+            "properties": {
+              "Bridge": {
+                "$ref": "#/components/schemas/Bridge"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -4852,6 +4872,42 @@
           "inactive": {
             "description": "`true` if validator has been \"evicted\"",
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Bridge": {
+        "description": "A bridge record pointing to a new `ValidatorBid` after the public key was changed.",
+        "type": "object",
+        "required": [
+          "era_id",
+          "new_validator_public_key",
+          "old_validator_public_key"
+        ],
+        "properties": {
+          "old_validator_public_key": {
+            "description": "Previous validator public key associated with the bid.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "new_validator_public_key": {
+            "description": "New validator public key associated with the bid.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "era_id": {
+            "description": "Era when bridge record was created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EraId"
+              }
+            ]
           }
         },
         "additionalProperties": false

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -2876,6 +2876,19 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "A bridge record pointing to a new `ValidatorBid` after the public key was changed.",
+            "type": "object",
+            "required": [
+              "Bridge"
+            ],
+            "properties": {
+              "Bridge": {
+                "$ref": "#/components/schemas/Bridge"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -2934,6 +2947,42 @@
           "inactive": {
             "description": "`true` if validator has been \"evicted\"",
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Bridge": {
+        "description": "A bridge record pointing to a new `ValidatorBid` after the public key was changed.",
+        "type": "object",
+        "required": [
+          "era_id",
+          "new_validator_public_key",
+          "old_validator_public_key"
+        ],
+        "properties": {
+          "old_validator_public_key": {
+            "description": "Previous validator public key associated with the bid.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "new_validator_public_key": {
+            "description": "New validator public key associated with the bid.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "era_id": {
+            "description": "Era when bridge record was created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EraId"
+              }
+            ]
           }
         },
         "additionalProperties": false
@@ -3890,6 +3939,13 @@
             "type": "string",
             "enum": [
               "ActivateBid"
+            ]
+          },
+          {
+            "description": "The `change_bid_public_key` native entry point, used to change a bid's public key.",
+            "type": "string",
+            "enum": [
+              "ChangeBidPublicKey"
             ]
           }
         ]

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -87,12 +87,12 @@ pub trait NodeClient: Send + Sync {
         parse_response::<Vec<StoredValue>>(&resp.into())?.ok_or(Error::EmptyEnvelope)
     }
 
-    async fn get_balance_by_state_root(
+    async fn read_balance(
         &self,
         state_identifier: Option<GlobalStateIdentifier>,
         purse_identifier: PurseIdentifier,
     ) -> Result<BalanceResponse, Error> {
-        let get = GlobalStateRequest::BalanceByStateRoot {
+        let get = GlobalStateRequest::Balance {
             state_identifier,
             purse_identifier,
         };

--- a/rpc_sidecar/src/rpcs/state.rs
+++ b/rpc_sidecar/src/rpcs/state.rs
@@ -277,7 +277,7 @@ impl RpcWithParams for GetBalance {
         let state_id = GlobalStateIdentifier::StateRootHash(params.state_root_hash);
         let purse_id = PortPurseIdentifier::Purse(purse_uref);
         let balance = node_client
-            .get_balance_by_state_root(Some(state_id), purse_id)
+            .read_balance(Some(state_id), purse_id)
             .await
             .map_err(|err| Error::NodeRequest("balance", err))?;
 
@@ -934,9 +934,9 @@ impl RpcWithParams for QueryBalance {
     ) -> Result<Self::ResponseResult, RpcError> {
         let purse_id = params.purse_identifier.into_port_purse_identifier();
         let balance = node_client
-            .get_balance_by_state_root(params.state_identifier, purse_id)
+            .read_balance(params.state_identifier, purse_id)
             .await
-            .map_err(|err| Error::NodeRequest("balance by state root", err))?;
+            .map_err(|err| Error::NodeRequest("balance", err))?;
         Ok(Self::ResponseResult {
             api_version: CURRENT_API_VERSION,
             balance: balance.available_balance,
@@ -1007,9 +1007,9 @@ impl RpcWithParams for QueryBalanceDetails {
     ) -> Result<Self::ResponseResult, RpcError> {
         let purse_id = params.purse_identifier.into_port_purse_identifier();
         let balance = node_client
-            .get_balance_by_state_root(params.state_identifier, purse_id)
+            .read_balance(params.state_identifier, purse_id)
             .await
-            .map_err(|err| Error::NodeRequest("balance by state root", err))?;
+            .map_err(|err| Error::NodeRequest("balance", err))?;
 
         let holds = balance
             .balance_holds
@@ -2040,11 +2040,7 @@ mod tests {
         ) -> Result<BinaryResponseAndRequest, ClientError> {
             match req {
                 BinaryRequest::Get(GetRequest::State(req))
-                    if matches!(
-                        &*req,
-                        GlobalStateRequest::BalanceByBlock { .. }
-                            | GlobalStateRequest::BalanceByStateRoot { .. }
-                    ) =>
+                    if matches!(&*req, GlobalStateRequest::Balance { .. }) =>
                 {
                     Ok(BinaryResponseAndRequest::new(
                         BinaryResponse::from_value(self.0.clone(), SUPPORTED_PROTOCOL_VERSION),

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,7 +14,10 @@ blake2 = { version = "0.9.0", optional = true }
 casper-types = { workspace = true, features = ["std"] }
 hex-buffer-serde = "0.3.0"
 hex_fmt = "0.3.0"
+itertools = { workspace = true }
+mockall = "0.12.1"
 once_cell = { workspace = true }
+pretty_assertions = "1.4.0"
 rand = { version = "0.8.5", optional = true }
 serde = { workspace = true, default-features = true, features = ["derive", "rc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc", "raw_value"] }
@@ -24,3 +27,7 @@ utoipa = { version = "4", features = ["rc_schema"] }
 [features]
 sse-data-testing = ["blake2", "casper-types/testing", "rand"]
 additional-metrics = []
+
+[dev-dependencies]
+casper-types = { workspace = true, features = ["std", "testing"] }
+rand = "0.8.3"

--- a/types/src/legacy_sse_data/fixtures.rs
+++ b/types/src/legacy_sse_data/fixtures.rs
@@ -1,0 +1,669 @@
+use super::LegacySseData;
+use crate::sse_data::SseData;
+
+pub fn legacy_block_added() -> LegacySseData {
+    serde_json::from_str(RAW_LEGACY_BLOCK_ADDED).unwrap()
+}
+
+pub fn legacy_block_added_from_v2() -> LegacySseData {
+    serde_json::from_str(RAW_LEGACY_BLOCK_ADDED_FROM_V2).unwrap()
+}
+
+pub fn block_added_v1() -> SseData {
+    serde_json::from_str(RAW_BLOCK_ADDED_V1).unwrap()
+}
+
+pub fn block_added_v2() -> SseData {
+    serde_json::from_str(RAW_BLOCK_ADDED_V2).unwrap()
+}
+
+pub fn api_version() -> SseData {
+    serde_json::from_str(RAW_API_VERSION).unwrap()
+}
+
+pub fn legacy_api_version() -> LegacySseData {
+    serde_json::from_str(RAW_API_VERSION).unwrap()
+}
+
+pub fn finality_signature_v1() -> SseData {
+    serde_json::from_str(RAW_FINALITY_SIGNATURE_V1).unwrap()
+}
+
+pub fn finality_signature_v2() -> SseData {
+    serde_json::from_str(RAW_FINALITY_SIGNATURE_V2).unwrap()
+}
+
+pub fn transaction_accepted() -> SseData {
+    serde_json::from_str(RAW_TRANSACTION_ACCEPTED).unwrap()
+}
+
+pub fn deploy_accepted() -> SseData {
+    serde_json::from_str(RAW_DEPLOY_ACCEPTED).unwrap()
+}
+
+pub fn legacy_deploy_accepted() -> LegacySseData {
+    serde_json::from_str(RAW_LEGACY_DEPLOY_ACCEPTED).unwrap()
+}
+
+pub fn deploy_expired() -> SseData {
+    serde_json::from_str(RAW_DEPLOY_EXPIRED).unwrap()
+}
+
+pub fn transaction_expired() -> SseData {
+    serde_json::from_str(RAW_TRANSACTION_EXPIRED).unwrap()
+}
+
+pub fn legacy_deploy_expired() -> LegacySseData {
+    serde_json::from_str(RAW_LEGACY_DEPLOY_EXPIRED).unwrap()
+}
+
+pub fn legacy_finality_signature() -> LegacySseData {
+    serde_json::from_str(RAW_LEGACY_FINALITY_SIGNATURE).unwrap()
+}
+
+pub fn fault() -> SseData {
+    serde_json::from_str(RAW_FAULT).unwrap()
+}
+
+pub fn legacy_fault() -> LegacySseData {
+    serde_json::from_str(RAW_LEGACY_FAULT).unwrap()
+}
+
+pub fn deploy_processed() -> SseData {
+    serde_json::from_str(RAW_DEPLOY_PROCESSED).unwrap()
+}
+
+pub fn legacy_deploy_processed() -> LegacySseData {
+    serde_json::from_str(RAW_LEGACY_DEPLOY_PROCESSED).unwrap()
+}
+
+const RAW_API_VERSION: &str = r#"{"ApiVersion":"2.0.0"}"#;
+
+const RAW_FINALITY_SIGNATURE_V2: &str = r#"{
+    "FinalitySignature": {
+      "V2": {
+        "block_hash": "45d7c385cba0a880cbc0068ccc6c58111d057d8190850b744c8e0450a24639d4",
+        "block_height": 60923,
+        "era_id": 139,
+        "chain_name_hash": "f087a92e6e7077b3deb5e00b14a904e34c7068a9410365435bc7ca5d3ac64301",
+        "signature": "01cc39996b8410b500a61c97f888b381546de77e13e8af1a509d3305021b079c1d54b29f3eac8370eb40af2a6419b81427e09cd3c2e72567357fa2120abb0bba06",
+        "public_key": "017536433a73f7562526f3e9fcb8d720428ae2d28788a9909f3c6f637a9d848a4b"
+      }
+    }
+  }"#;
+
+const RAW_FINALITY_SIGNATURE_V1: &str = r#"{
+"FinalitySignature": {
+    "V1": {
+      "block_hash": "45d7c385cba0a880cbc0068ccc6c58111d057d8190850b744c8e0450a24639d4",
+      "era_id": 139,
+      "signature": "01cc39996b8410b500a61c97f888b381546de77e13e8af1a509d3305021b079c1d54b29f3eac8370eb40af2a6419b81427e09cd3c2e72567357fa2120abb0bba06",
+      "public_key": "017536433a73f7562526f3e9fcb8d720428ae2d28788a9909f3c6f637a9d848a4b"
+    }
+}
+}"#;
+
+const RAW_LEGACY_FINALITY_SIGNATURE: &str = r#"{
+    "FinalitySignature": {
+        "block_hash": "45d7c385cba0a880cbc0068ccc6c58111d057d8190850b744c8e0450a24639d4",
+        "era_id": 139,
+        "signature": "01cc39996b8410b500a61c97f888b381546de77e13e8af1a509d3305021b079c1d54b29f3eac8370eb40af2a6419b81427e09cd3c2e72567357fa2120abb0bba06",
+        "public_key": "017536433a73f7562526f3e9fcb8d720428ae2d28788a9909f3c6f637a9d848a4b"
+    }
+    }"#;
+
+const RAW_TRANSACTION_ACCEPTED: &str = r#"
+{
+    "TransactionAccepted": {
+        "Version1": {
+            "hash": "2084a40f58874fb2997e029e61ec55e3d5a6cd5f6de77a1d42dcaf21aeddc760",
+            "header": {
+                "chain_name":"⸻⋉◬⸗ⶨ⼄≙⡫⨁ⶃℍ⊨⇏ⴲⲋ⪝⣬ⴂ⨨⪯⿉⺙⚚⻰⒯ⶖ⟽⬪❴⴯╽♥⅏⏵❲⃽ⶁ⾠⸗◩⋑Ⅹ♼⺓⊻⼠Ⓩ∇Ⅺ⸔◘⠝◓⚾◯⦁★⢹␄⍆⨿⵮⭭⮛⸹⃻⹶⎶⟆⛎⤑₇⩐╨⋸⠸₈⥡ⷔ⹪⤛⭺⵫Ⲗ⃁⪏⫵⚎⁘⦳☉␛Ⲹ⥝⇡Ⰰ⫂⁎⍆⼸",
+                "timestamp": "2020-08-07T01:30:25.521Z",
+                "ttl": "5h 6m 46s 219ms",
+                "body_hash": "11ddedb85acbe04217e4f322663e7a3b90630321cdff7d7a8f0ce97fd76ead9a",
+                "pricing_mode": {
+                    "Fixed": {
+                        "gas_price_tolerance": 5
+                    }
+                },
+                "initiator_addr": {
+                    "PublicKey": "01b0c1bc1910f3e2e5fa8329d642b34e72e34183e0a2b239021906df8d7d968fcd"
+                }
+            },
+            "body": {
+                "args": [
+                    [
+                        "source",
+                        {
+                            "cl_type": {
+                                "Option": "URef"
+                            },
+                            "bytes": "01d4ce239a968d7ac214964f714f6aa267612d1da1ec9c65dfc40a99d0e1a673ce02",
+                            "parsed": "uref-d4ce239a968d7ac214964f714f6aa267612d1da1ec9c65dfc40a99d0e1a673ce-002"
+                        }
+                    ],
+                    [
+                        "target",
+                        {
+                            "cl_type": "PublicKey",
+                            "bytes": "015a977c34eeff036613837814822a1a44986f2a7057c17436d01d200132614c58",
+                            "parsed": "015a977c34eeff036613837814822a1a44986f2a7057c17436d01d200132614c58"
+                        }
+                    ],
+                    [
+                        "amount",
+                        {
+                            "cl_type": "U512",
+                            "bytes": "08b30d8646748b0f87",
+                            "parsed": "9732150651286588851"
+                        }
+                    ],
+                    [
+                        "id",
+                        {
+                            "cl_type": {
+                                "Option": "U64"
+                            },
+                            "bytes": "01dfd56bb1e2ac2494",
+                            "parsed": 10674847106414138847
+                        }
+                    ]
+                ],
+                "target": "Native",
+                "entry_point": "Transfer",
+                "scheduling": {
+                    "FutureTimestamp": "2020-08-07T01:32:59.428Z"
+                }
+            },
+            "approvals": [
+                {
+                    "signer": "01b0c1bc1910f3e2e5fa8329d642b34e72e34183e0a2b239021906df8d7d968fcd",
+                    "signature": "01fb52d40bd36c813ca69b982f6b7f4bac79314187e51e69128fa4d87fbb2cfe8e803b2eedaa6f39566ca3a4dc59ac418824aa2e7fc05611910162cf9f6a164902"
+                }
+            ]
+        }
+    }
+}
+"#;
+
+const RAW_LEGACY_DEPLOY_ACCEPTED: &str = r#"
+{
+    "DeployAccepted": {
+        "hash": "5a7709969c210db93d3c21bf49f8bf705d7c75a01609f606d04b0211af171d43",
+        "header": {
+            "account": "02022c07e061d6e0b43bbaa25717b021c2ddc0f701a223946a0883b57ae842917438",
+            "timestamp": "2020-08-07T01:28:27.360Z",
+            "ttl": "4m 22s",
+            "gas_price": 72,
+            "body_hash": "aa2a111c086628a161001160756c5884e32fde0356bb85f484a3e55682ad089f",
+            "dependencies": [],
+            "chain_name": "casper-example"
+        },
+        "payment": {
+            "StoredContractByName": {
+                "name": "casper-example",
+                "entry_point": "example-entry-point",
+                "args": [
+                    [
+                        "amount",
+                        {
+                            "cl_type": "U512",
+                            "bytes": "0400f90295",
+                            "parsed": "2500000000"
+                        }
+                    ]
+                ]
+            }
+        },
+        "session": {
+            "StoredContractByHash": {
+                "hash": "dfb621e7012df48fe1d40fd8015b5e2396c477c9587e996678551148a06d3a89",
+                "entry_point": "8sY9fUUCwoiFZmxKo8kj",
+                "args": [
+                    [
+                        "YbZWtEuL4D6oMTJmUWvj",
+                        {
+                            "cl_type": {
+                                "List": "U8"
+                            },
+                            "bytes": "5a000000909ffe7807b03a5db0c3c183648710db16d408d8425a4e373fc0422a4efed1ab0040bc08786553fcac4521528c9fafca0b0fb86f4c6e9fb9db7a1454dda8ed612c4ea4c9a6378b230ae1e3c236e37d6ebee94339a56cb4be582a",
+                            "parsed": [
+                                144,
+                                159,
+                                254,
+                                120,
+                                7
+                            ]
+                        }
+                    ]
+                ]
+            }
+        },
+        "approvals": [
+            {
+                "signer": "02022c07e061d6e0b43bbaa25717b021c2ddc0f701a223946a0883b57ae842917438",
+                "signature": "025d0a7ba37bebe6774681ca5adecb70fa4eef56821eb344bf0f6867e171a899a87edb2b8bf70f2cb47a1670a6baf2cded1fad535ee53a2f65da91c82ebf30945b"
+            }
+        ]
+    }
+}"#;
+
+const RAW_DEPLOY_ACCEPTED: &str = r#"
+{
+    "TransactionAccepted": {
+        "Deploy": {
+            "hash": "5a7709969c210db93d3c21bf49f8bf705d7c75a01609f606d04b0211af171d43",
+            "header": {
+                "account": "02022c07e061d6e0b43bbaa25717b021c2ddc0f701a223946a0883b57ae842917438",
+                "timestamp": "2020-08-07T01:28:27.360Z",
+                "ttl": "4m 22s",
+                "gas_price": 72,
+                "body_hash": "aa2a111c086628a161001160756c5884e32fde0356bb85f484a3e55682ad089f",
+                "dependencies": [],
+                "chain_name": "casper-example"
+            },
+            "payment": {
+                "StoredContractByName": {
+                    "name": "casper-example",
+                    "entry_point": "example-entry-point",
+                    "args": [
+                        [
+                            "amount",
+                            {
+                                "cl_type": "U512",
+                                "bytes": "0400f90295",
+                                "parsed": "2500000000"
+                            }
+                        ]
+                    ]
+                }
+            },
+            "session": {
+                "StoredContractByHash": {
+                    "hash": "dfb621e7012df48fe1d40fd8015b5e2396c477c9587e996678551148a06d3a89",
+                    "entry_point": "8sY9fUUCwoiFZmxKo8kj",
+                    "args": [
+                        [
+                            "YbZWtEuL4D6oMTJmUWvj",
+                            {
+                                "cl_type": {
+                                    "List": "U8"
+                                },
+                                "bytes": "5a000000909ffe7807b03a5db0c3c183648710db16d408d8425a4e373fc0422a4efed1ab0040bc08786553fcac4521528c9fafca0b0fb86f4c6e9fb9db7a1454dda8ed612c4ea4c9a6378b230ae1e3c236e37d6ebee94339a56cb4be582a",
+                                "parsed": [
+                                    144,
+                                    159,
+                                    254,
+                                    120,
+                                    7
+                                ]
+                            }
+                        ]
+                    ]
+                }
+            },
+            "approvals": [
+                {
+                    "signer": "02022c07e061d6e0b43bbaa25717b021c2ddc0f701a223946a0883b57ae842917438",
+                    "signature": "025d0a7ba37bebe6774681ca5adecb70fa4eef56821eb344bf0f6867e171a899a87edb2b8bf70f2cb47a1670a6baf2cded1fad535ee53a2f65da91c82ebf30945b"
+                }
+            ]
+        }
+    }
+}
+"#;
+
+const RAW_DEPLOY_EXPIRED: &str = r#"
+{
+    "TransactionExpired": {
+        "transaction_hash": {
+            "Deploy": "565d7147e28be402c34208a133fd59fde7ac785ae5f0298cb5fb7adfb1b054a8"
+        }
+    }
+}
+"#;
+
+const RAW_TRANSACTION_EXPIRED: &str = r#"
+{
+    "TransactionExpired": {
+        "transaction_hash": {
+            "Version1": "8c22ae866be3287b6374592083b17cbaf4b0452d7a55adb2a4e53bb0295c0d76"
+        }
+    }
+}
+"#;
+
+const RAW_LEGACY_DEPLOY_EXPIRED: &str = r#"
+{
+    "DeployExpired": {
+        "deploy_hash": "565d7147e28be402c34208a133fd59fde7ac785ae5f0298cb5fb7adfb1b054a8"
+    }
+}
+"#;
+
+const RAW_FAULT: &str = r#"
+{
+    "Fault": {
+        "era_id": 769794,
+        "public_key": "02034ce1acbceeb5eb2b20eeeef9965e3ca8e7a95655f2089342bcbb51319a0d70d1",
+        "timestamp": "2020-08-07T01:30:59.692Z"
+    }
+}
+"#;
+
+const RAW_LEGACY_FAULT: &str = r#"
+{
+    "Fault": {
+        "era_id": 769794,
+        "public_key": "02034ce1acbceeb5eb2b20eeeef9965e3ca8e7a95655f2089342bcbb51319a0d70d1",
+        "timestamp": "2020-08-07T01:30:59.692Z"
+    }
+}
+"#;
+
+const RAW_LEGACY_BLOCK_ADDED: &str = r#"
+{
+    "BlockAdded": {
+        "block_hash": "d59359690ca5a251b513185da0767f744e77645adec82bb6ff785a89edc7591c",
+        "block": {
+            "hash": "d59359690ca5a251b513185da0767f744e77645adec82bb6ff785a89edc7591c",
+            "header": {
+                "parent_hash": "90ca56a697f8b1b19cba08c642fd7f04669b8cd49bb9d652fca989f8a9f8bcea",
+                "state_root_hash": "9cce223fdbeab41dbbcf0b62f3fd857373131378d51776de26bb9f4fefe1e849",
+                "body_hash": "5f37be399c15b2394af48243ce10a62a7d12769dc5f7740b18ad3bf55bde5271",
+                "random_bit": true,
+                "accumulated_seed": "b3e1930565a80a874a443eaadefa1a340927fb8b347729bbd93e93935a47a9e4",
+                "era_end": {
+                    "era_report": {
+                        "equivocators": [
+                            "0203c9da857cfeccf001ce00720ae2e0d083629858b60ac05dd285ce0edae55f0c8e",
+                            "02026fb7b629a2ec0132505cdf036f6ffb946d03a1c9b5da57245af522b842f145be"
+                        ],
+                        "rewards": [
+                            {
+                                "validator": "01235b932586ae5cc3135f7a0dc723185b87e5bd3ae0ac126a92c14468e976ff25",
+                                "amount": 129457537
+                            }
+                        ],
+                        "inactive_validators": []
+                    },
+                    "next_era_validator_weights": [
+                        {
+                            "validator": "0198957673ad060503e2ec7d98dc71af6f90ad1f854fe18025e3e7d0d1bbe5e32b",
+                            "weight": "1"
+                        },
+                        {
+                            "validator": "02022d6bc4e3012cc4ae467b5525111cf7ed65883b05a1d924f1e654c64fad3a027c",
+                            "weight": "2"
+                        }
+                    ]
+                },
+                "timestamp": "2024-04-25T20:00:35.640Z",
+                "era_id": 601701,
+                "height": 6017012,
+                "protocol_version": "1.0.0"
+            },
+            "body": {
+                "proposer": "0108c3b531fbbbb53f4752ab3c3c6ba72c9fb4b9852e2822622d8f936428819881",
+                "deploy_hashes": [
+                    "06950e4374dc88685634ec30bcddd68e6b46c109ccf6d29e2dfcf5367df75571",
+                    "27a89dd58e6297a5244342b68b117afe2555131b896ad6ed4321edcd4130ae7b"
+                ],
+                "transfer_hashes": [
+                    "3e30b6c1c5dbca9277425846b42dc832cd3d8ce889c38d6bfc8bd95b3e1c403e",
+                    "c990ba47146270655eaacc53d4115cbd980697f3d4e9c76bccfdfce82af6ce08"
+                ]
+            }
+        }
+    }
+}"#;
+
+const RAW_BLOCK_ADDED_V1: &str = r#"
+{
+    "BlockAdded": {
+        "block_hash": "d59359690ca5a251b513185da0767f744e77645adec82bb6ff785a89edc7591c",
+        "block": {
+            "Version1": {
+                "hash": "d59359690ca5a251b513185da0767f744e77645adec82bb6ff785a89edc7591c",
+                "header": {
+                    "parent_hash": "90ca56a697f8b1b19cba08c642fd7f04669b8cd49bb9d652fca989f8a9f8bcea",
+                    "state_root_hash": "9cce223fdbeab41dbbcf0b62f3fd857373131378d51776de26bb9f4fefe1e849",
+                    "body_hash": "5f37be399c15b2394af48243ce10a62a7d12769dc5f7740b18ad3bf55bde5271",
+                    "random_bit": true,
+                    "accumulated_seed": "b3e1930565a80a874a443eaadefa1a340927fb8b347729bbd93e93935a47a9e4",
+                    "era_end": {
+                        "era_report": {
+                            "equivocators": [
+                                "0203c9da857cfeccf001ce00720ae2e0d083629858b60ac05dd285ce0edae55f0c8e",
+                                "02026fb7b629a2ec0132505cdf036f6ffb946d03a1c9b5da57245af522b842f145be"
+                            ],
+                            "rewards": [
+                                {
+                                    "validator": "01235b932586ae5cc3135f7a0dc723185b87e5bd3ae0ac126a92c14468e976ff25",
+                                    "amount": 129457537
+                                }
+                            ],
+                            "inactive_validators": []
+                        },
+                        "next_era_validator_weights": [
+                            {
+                                "validator": "0198957673ad060503e2ec7d98dc71af6f90ad1f854fe18025e3e7d0d1bbe5e32b",
+                                "weight": "1"
+                            },
+                            {
+                                "validator": "02022d6bc4e3012cc4ae467b5525111cf7ed65883b05a1d924f1e654c64fad3a027c",
+                                "weight": "2"
+                            }
+                        ]
+                    },
+                    "timestamp": "2024-04-25T20:00:35.640Z",
+                    "era_id": 601701,
+                    "height": 6017012,
+                    "protocol_version": "1.0.0"
+                },
+                "body": {
+                    "proposer": "0108c3b531fbbbb53f4752ab3c3c6ba72c9fb4b9852e2822622d8f936428819881",
+                    "deploy_hashes": [
+                    "06950e4374dc88685634ec30bcddd68e6b46c109ccf6d29e2dfcf5367df75571",
+                    "27a89dd58e6297a5244342b68b117afe2555131b896ad6ed4321edcd4130ae7b"
+                ],
+                "transfer_hashes": [
+                    "3e30b6c1c5dbca9277425846b42dc832cd3d8ce889c38d6bfc8bd95b3e1c403e",
+                    "c990ba47146270655eaacc53d4115cbd980697f3d4e9c76bccfdfce82af6ce08"
+                ]
+                }
+            }
+        }
+    }
+}
+"#;
+
+const RAW_BLOCK_ADDED_V2: &str = r#"{
+    "BlockAdded": {
+        "block_hash": "2df9fb8909443fba928ed0536a79780cdb4557d0c05fdf762a1fd61141121422",
+        "block": {
+            "Version2": {
+                "hash": "2df9fb8909443fba928ed0536a79780cdb4557d0c05fdf762a1fd61141121422",
+                "header": {
+                    "parent_hash": "b8f5e9afd2e54856aa1656f962d07158f0fdf9cfac0f9992875f31f6bf2623a2",
+                    "state_root_hash": "cbf02d08bb263aa8915507c172b5f590bbddcd68693fb1c71758b5684b011730",
+                    "body_hash": "6041ab862a1e14a43a8e8a9a42dad27091915a337d18060c22bd3fe7b4f39607",
+                    "random_bit": false,
+                    "accumulated_seed": "a0e424710f4fba036ba450b40f2bd7a842b176cf136f3af1952a2a13eb02616c",
+                    "era_end": {
+                        "equivocators": [
+                            "01cc718e9dea652577bffad3471d0db7d03ba30923780a2a8fd1e3dd9b4e72dc54",
+                            "0203e4532e401326892aa8ebc16b6986bd35a6c96a1f16c28db67fd7e87cb6913817",
+                            "020318a52d5b2d545def8bf0ee5ea7ddea52f1fbf106c8b69848e40c5460e20c9f62"
+                        ],
+                        "inactive_validators": ["01cc718e9dea652577bffad3471d0db7d03ba30923780a2a8fd1e3dd9b4e72dc55", "01cc718e9dea652577bffad3471d0db7d03ba30923780a2a8fd1e3dd9b4e72dc56"],
+                        "next_era_validator_weights": [
+                            {"validator": "02038b238d774c3c4228a0430e3a078e1a2533f9c87cccbcf695637502d8d6057a63", "weight": "1"},
+                            {"validator": "0102ffd4d2812d68c928712edd012fbcad54367bc6c5c254db22cf696772856566", "weight": "2"}
+                        ],
+                        "rewards": {
+                            "02028b18c949d849b377988ea5191b39340975db25f8b80f37cc829c9f79dbfb19fc": "749546792",
+                            "02028002c063228ff4e9d22d69154c499b86a4f7fdbf1d1e20f168b62da537af64c2": "788342677",
+                            "02038efa405f648c72f36b0e5f37db69ab213d44404591b24de21383d8cc161101ec": "86241635",
+                            "01f6bbd4a6fd10534290c58edb6090723d481cea444a8e8f70458e5136ea8c733c": "941794198"
+                        },
+                        "next_era_gas_price": 1
+                    },
+                    "timestamp": "2024-04-25T20:31:39.895Z",
+                    "era_id": 419571,
+                    "height": 4195710,
+                    "protocol_version": "1.0.0",
+                    "current_gas_price": 1
+                },
+                "body": {
+                    "proposer": "01d3eec0445635f136ae560b43e9d8f656a6ba925f01293eaf2610b39ebe0fc28d",
+                    "mint": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e80"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e81"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e82"}],
+                    "auction": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e83"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e84"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e85"}],
+                    "install_upgrade": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e86"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e87"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e88"}],
+                    "standard": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e89"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e90"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e91"}],
+                    "rewarded_signatures": [[240],[0],[0]]
+                }
+            }
+        }
+    }
+}"#;
+
+const RAW_LEGACY_BLOCK_ADDED_FROM_V2: &str = r#"{
+    "BlockAdded": {
+        "block_hash": "2df9fb8909443fba928ed0536a79780cdb4557d0c05fdf762a1fd61141121422",
+        "block": {
+            "hash": "2df9fb8909443fba928ed0536a79780cdb4557d0c05fdf762a1fd61141121422",
+            "header": {
+                "parent_hash": "b8f5e9afd2e54856aa1656f962d07158f0fdf9cfac0f9992875f31f6bf2623a2",
+                "state_root_hash": "cbf02d08bb263aa8915507c172b5f590bbddcd68693fb1c71758b5684b011730",
+                "body_hash": "6041ab862a1e14a43a8e8a9a42dad27091915a337d18060c22bd3fe7b4f39607",
+                "random_bit": false,
+                "accumulated_seed": "a0e424710f4fba036ba450b40f2bd7a842b176cf136f3af1952a2a13eb02616c",
+                "era_end": {
+                    "era_report": {
+                        "equivocators": [
+                            "01cc718e9dea652577bffad3471d0db7d03ba30923780a2a8fd1e3dd9b4e72dc54",
+                            "0203e4532e401326892aa8ebc16b6986bd35a6c96a1f16c28db67fd7e87cb6913817",
+                            "020318a52d5b2d545def8bf0ee5ea7ddea52f1fbf106c8b69848e40c5460e20c9f62"
+                        ],
+                        "rewards": [
+                            {
+                                "validator": "01f6bbd4a6fd10534290c58edb6090723d481cea444a8e8f70458e5136ea8c733c",
+                                "amount": 941794198
+                            },
+                            {
+                                "validator": "02028002c063228ff4e9d22d69154c499b86a4f7fdbf1d1e20f168b62da537af64c2",
+                                "amount": 788342677
+                            },
+                            {
+                                "validator": "02028b18c949d849b377988ea5191b39340975db25f8b80f37cc829c9f79dbfb19fc",
+                                "amount": 749546792
+                            },
+                            {
+                                "validator": "02038efa405f648c72f36b0e5f37db69ab213d44404591b24de21383d8cc161101ec",
+                                "amount": 86241635
+                            }
+                        ],
+                        "inactive_validators": [
+                            "01cc718e9dea652577bffad3471d0db7d03ba30923780a2a8fd1e3dd9b4e72dc55",
+                            "01cc718e9dea652577bffad3471d0db7d03ba30923780a2a8fd1e3dd9b4e72dc56"
+                        ]
+                    },
+                    "next_era_validator_weights": [
+                        {
+                            "validator": "0102ffd4d2812d68c928712edd012fbcad54367bc6c5c254db22cf696772856566",
+                            "weight": "2"
+                        },
+                        {
+                            "validator": "02038b238d774c3c4228a0430e3a078e1a2533f9c87cccbcf695637502d8d6057a63",
+                            "weight": "1"
+                        }
+                    ]
+                },
+                "timestamp": "2024-04-25T20:31:39.895Z",
+                "era_id": 419571,
+                "height": 4195710,
+                "protocol_version": "1.0.0"
+            },
+            "body": {
+                "proposer": "01d3eec0445635f136ae560b43e9d8f656a6ba925f01293eaf2610b39ebe0fc28d",
+                "deploy_hashes": [
+                    "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e89",
+                    "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e90"
+                ],
+                "transfer_hashes": [
+                    "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e80",
+                    "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e81"
+                ]
+            }
+        }
+    }
+}"#;
+
+const RAW_DEPLOY_PROCESSED: &str = r#"{
+    "TransactionProcessed": {
+        "transaction_hash": {
+            "Deploy": "1660c3971ba4283583e4abc1cbef5ea0845a37300ae40a8728ae2684c1b1a5d2"
+        },
+        "initiator_addr": {
+            "PublicKey": "0203d98e2ec694b981cebd7cf35ac531d8717e86dc35912f2536b8807ad550621147"
+        },
+        "timestamp": "2020-08-07T01:24:27.283Z",
+        "ttl": "4h 11m 524ms",
+        "block_hash": "e91cd454e94f2e3d155fa71105251cd0905e91067872a743d5d22974caabab06",
+        "execution_result": {
+            "Version2": {
+                "initiator": {
+                    "PublicKey": "0203d98e2ec694b981cebd7cf35ac531d8717e86dc35912f2536b8807ad550621147"
+                },
+                "error_message": "Error message 18290057561582514745",
+                "limit": "11209375253254652626",
+                "consumed": "10059559442643035623",
+                "cost": "44837501013018610504",
+                "payment": [
+                    {
+                        "source": "uref-da6b7bf686013e620f7efd057bb0285ab512324b5e69be0f16691fd9c6acb4e4-005"
+                    }
+                ],
+                "transfers": [],
+                "effects": [],
+                "size_estimate": 521
+            }
+        },
+        "messages": [
+            {
+                "entity_hash": "entity-system-fbd35eaf71f295b3bf35a295e705f629bbea28cefedfc109eda1205fb3650bad",
+                "message": {
+                    "String": "cs5rHI2Il75nRJ7GLs7BQM5CilvzMqu0dgFuj57FkqEs3431LJ1qfsZActb05hzR"
+                },
+                "topic_name": "7DnsHE3NL4PRaYuPcY90bECdnd7D78lF",
+                "topic_name_hash": "f75840ed75ad1c85856de00d2ca865a7608b46a933d81c64ff8907ec620d6e83",
+                "topic_index": 2222189259,
+                "block_index": 11650550294672125610
+            }
+        ]
+    }
+}"#;
+
+const RAW_LEGACY_DEPLOY_PROCESSED: &str = r#"{
+    "DeployProcessed": {
+        "deploy_hash": "1660c3971ba4283583e4abc1cbef5ea0845a37300ae40a8728ae2684c1b1a5d2",
+        "account": "0203d98e2ec694b981cebd7cf35ac531d8717e86dc35912f2536b8807ad550621147",
+        "timestamp": "2020-08-07T01:24:27.283Z",
+        "ttl": "4h 11m 524ms",
+        "dependencies": [],
+        "block_hash": "e91cd454e94f2e3d155fa71105251cd0905e91067872a743d5d22974caabab06",
+        "execution_result": {
+            "Failure": {
+                "effect": {
+                    "operations": [],
+                    "transforms": []
+                },
+                "transfers": [],
+                "cost": "44837501013018610504",
+                "error_message": "Error message 18290057561582514745"
+            }
+        }
+    }
+}"#;

--- a/types/src/legacy_sse_data/mod.rs
+++ b/types/src/legacy_sse_data/mod.rs
@@ -164,7 +164,7 @@ fn maybe_translate_transaction_processed(
         TransactionHash::Deploy(deploy_hash) => {
             let account = match initiator_addr {
                 InitiatorAddr::PublicKey(public_key) => public_key,
-                InitiatorAddr::AccountHash(_) => return None, //This shouldn't happen since we alredy are in TransactionHas::Deploy
+                InitiatorAddr::AccountHash(_) => return None, //This shouldn't happen since we already are in TransactionHash::Deploy
             };
             let execution_result = match execution_result {
                 ExecutionResult::V1(result) => result.clone(),

--- a/types/src/legacy_sse_data/mod.rs
+++ b/types/src/legacy_sse_data/mod.rs
@@ -1,0 +1,227 @@
+use self::{
+    translate_block_added::{build_default_block_added_translator, BlockAddedTranslator},
+    translate_execution_result::{
+        build_default_execution_result_translator, ExecutionResultV2Translator,
+    },
+};
+use crate::sse_data::SseData;
+use casper_types::{
+    execution::{ExecutionResult, ExecutionResultV1},
+    BlockHash, Deploy, DeployHash, EraId, FinalitySignature, FinalitySignatureV1,
+    FinalitySignatureV2, InitiatorAddr, ProtocolVersion, PublicKey, Signature, TimeDiff, Timestamp,
+    Transaction, TransactionHash,
+};
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+mod fixtures;
+mod structs;
+mod translate_block_added;
+mod translate_deploy_hashes;
+mod translate_execution_result;
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+pub enum LegacySseData {
+    ApiVersion(ProtocolVersion),
+    DeployAccepted(Deploy),
+    DeployProcessed {
+        deploy_hash: Box<DeployHash>,
+        account: Box<PublicKey>,
+        timestamp: Timestamp,
+        ttl: TimeDiff,
+        dependencies: Vec<DeployHash>,
+        block_hash: Box<BlockHash>,
+        execution_result: Box<ExecutionResultV1>,
+    },
+    DeployExpired {
+        deploy_hash: DeployHash,
+    },
+    BlockAdded {
+        block_hash: BlockHash,
+        block: structs::BlockV1,
+    },
+    Fault {
+        era_id: EraId,
+        public_key: PublicKey,
+        timestamp: Timestamp,
+    },
+    FinalitySignature(LegacyFinalitySignature),
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+pub struct LegacyFinalitySignature {
+    block_hash: BlockHash,
+    era_id: EraId,
+    signature: Signature,
+    public_key: PublicKey,
+}
+
+impl LegacyFinalitySignature {
+    fn from_v1(finality_signature: &FinalitySignatureV1) -> Self {
+        LegacyFinalitySignature {
+            block_hash: *finality_signature.block_hash(),
+            era_id: finality_signature.era_id(),
+            signature: *finality_signature.signature(),
+            public_key: finality_signature.public_key().clone(),
+        }
+    }
+
+    fn from_v2(finality_signature: &FinalitySignatureV2) -> Self {
+        LegacyFinalitySignature {
+            block_hash: *finality_signature.block_hash(),
+            era_id: finality_signature.era_id(),
+            signature: *finality_signature.signature(),
+            public_key: finality_signature.public_key().clone(),
+        }
+    }
+}
+
+impl LegacySseData {
+    pub fn from(data: &SseData) -> Option<Self> {
+        match data {
+            SseData::ApiVersion(protocol_version) => {
+                Some(LegacySseData::ApiVersion(*protocol_version))
+            }
+            SseData::SidecarVersion(_) => None,
+            SseData::Shutdown => None,
+            SseData::BlockAdded { block_hash, block } => {
+                build_default_block_added_translator().translate(block_hash, block)
+            }
+            SseData::TransactionAccepted(transaction) => {
+                maybe_translate_transaction_accepted(transaction)
+            }
+            SseData::TransactionProcessed {
+                transaction_hash,
+                initiator_addr,
+                timestamp,
+                ttl,
+                block_hash,
+                execution_result,
+                messages: _,
+            } => maybe_translate_transaction_processed(
+                transaction_hash,
+                initiator_addr,
+                timestamp,
+                ttl,
+                block_hash,
+                execution_result,
+            ),
+            SseData::TransactionExpired { transaction_hash } => {
+                maybe_translate_deploy_expired(transaction_hash)
+            }
+            SseData::Fault {
+                era_id,
+                public_key,
+                timestamp,
+            } => maybe_translate_fault(era_id, public_key, timestamp),
+            SseData::FinalitySignature(fs) => Some(translate_finality_signature(fs)),
+            SseData::Step { .. } => None, //we don't translate steps
+        }
+    }
+}
+
+fn translate_finality_signature(fs: &FinalitySignature) -> LegacySseData {
+    match fs {
+        FinalitySignature::V1(v1) => {
+            LegacySseData::FinalitySignature(LegacyFinalitySignature::from_v1(v1))
+        }
+        FinalitySignature::V2(v2) => {
+            LegacySseData::FinalitySignature(LegacyFinalitySignature::from_v2(v2))
+        }
+    }
+}
+
+fn maybe_translate_fault(
+    era_id: &EraId,
+    public_key: &PublicKey,
+    timestamp: &Timestamp,
+) -> Option<LegacySseData> {
+    Some(LegacySseData::Fault {
+        era_id: *era_id,
+        public_key: public_key.clone(),
+        timestamp: *timestamp,
+    })
+}
+
+fn maybe_translate_deploy_expired(transaction_hash: &TransactionHash) -> Option<LegacySseData> {
+    match transaction_hash {
+        TransactionHash::Deploy(deploy_hash) => Some(LegacySseData::DeployExpired {
+            deploy_hash: *deploy_hash,
+        }),
+        TransactionHash::V1(_) => None,
+    }
+}
+
+fn maybe_translate_transaction_processed(
+    transaction_hash: &TransactionHash,
+    initiator_addr: &InitiatorAddr,
+    timestamp: &Timestamp,
+    ttl: &TimeDiff,
+    block_hash: &BlockHash,
+    execution_result: &ExecutionResult,
+) -> Option<LegacySseData> {
+    match transaction_hash {
+        TransactionHash::Deploy(deploy_hash) => {
+            let account = match initiator_addr {
+                InitiatorAddr::PublicKey(public_key) => public_key,
+                InitiatorAddr::AccountHash(_) => return None, //This shouldn't happen since we alredy are in TransactionHas::Deploy
+            };
+            let execution_result = match execution_result {
+                ExecutionResult::V1(result) => result.clone(),
+                ExecutionResult::V2(result) => {
+                    let maybe_result =
+                        build_default_execution_result_translator().translate(result);
+                    maybe_result?
+                }
+            };
+            Some(LegacySseData::DeployProcessed {
+                deploy_hash: Box::new(*deploy_hash),
+                account: Box::new(account.clone()),
+                timestamp: *timestamp,
+                ttl: *ttl,
+                dependencies: Vec::new(),
+                block_hash: Box::new(*block_hash),
+                execution_result: Box::new(execution_result),
+            })
+        }
+        _ => None, //V1 transactions can't be interpreted in the old format.
+    }
+}
+
+fn maybe_translate_transaction_accepted(transaction: &Transaction) -> Option<LegacySseData> {
+    match transaction {
+        Transaction::Deploy(deploy) => Some(LegacySseData::DeployAccepted(deploy.clone())),
+        _ => None, //V2 transactions can't be interpreted in the old format.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fixtures::*;
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_translate_sse_to_legacy() {
+        for (sse_data, expected) in sse_translation_scenarios() {
+            let legacy_fs = LegacySseData::from(&sse_data);
+            assert_eq!(legacy_fs, expected);
+        }
+    }
+
+    fn sse_translation_scenarios() -> Vec<(SseData, Option<LegacySseData>)> {
+        vec![
+            (api_version(), Some(legacy_api_version())),
+            (finality_signature_v1(), Some(legacy_finality_signature())),
+            (finality_signature_v2(), Some(legacy_finality_signature())),
+            (transaction_accepted(), None),
+            (deploy_accepted(), Some(legacy_deploy_accepted())),
+            (deploy_expired(), Some(legacy_deploy_expired())),
+            (transaction_expired(), None),
+            (fault(), Some(legacy_fault())),
+            (block_added_v1(), Some(legacy_block_added())),
+            (block_added_v2(), Some(legacy_block_added_from_v2())),
+            (deploy_processed(), Some(legacy_deploy_processed())),
+        ]
+    }
+}

--- a/types/src/legacy_sse_data/structs.rs
+++ b/types/src/legacy_sse_data/structs.rs
@@ -1,0 +1,89 @@
+use casper_types::{
+    BlockHash, BlockHeaderV1, DeployHash, Digest, EraEndV1, EraId, ProtocolVersion, PublicKey,
+    Timestamp,
+};
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+pub struct BlockV1 {
+    pub(super) hash: BlockHash,
+    pub(super) header: BlockHeaderV1,
+    pub(super) body: BlockBodyV1,
+}
+
+impl BlockV1 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        parent_hash: BlockHash,
+        state_root_hash: Digest,
+        body_hash: Digest,
+        random_bit: bool,
+        accumulated_seed: Digest,
+        era_end: Option<EraEndV1>,
+        timestamp: Timestamp,
+        era_id: EraId,
+        height: u64,
+        protocol_version: ProtocolVersion,
+        proposer: PublicKey,
+        block_hash: BlockHash,
+        deploy_hashes: Vec<DeployHash>,
+        transfer_hashes: Vec<DeployHash>,
+    ) -> Self {
+        let body = BlockBodyV1::new(proposer, deploy_hashes, transfer_hashes);
+
+        let header = BlockHeaderV1::new(
+            parent_hash,
+            state_root_hash,
+            body_hash,
+            random_bit,
+            accumulated_seed,
+            era_end,
+            timestamp,
+            era_id,
+            height,
+            protocol_version,
+            OnceCell::from(block_hash),
+        );
+        Self::new_from_header_and_body(header, body)
+    }
+
+    pub fn new_from_header_and_body(header: BlockHeaderV1, body: BlockBodyV1) -> Self {
+        let hash = header.block_hash();
+        BlockV1 { hash, header, body }
+    }
+
+    pub fn from(hash: BlockHash, header: &BlockHeaderV1, body: &casper_types::BlockBodyV1) -> Self {
+        let legacy_body = BlockBodyV1::new(
+            body.proposer().clone(),
+            body.deploy_hashes().to_vec(),
+            body.transfer_hashes().to_vec(),
+        );
+        BlockV1 {
+            hash,
+            header: header.clone(),
+            body: legacy_body,
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+pub struct BlockBodyV1 {
+    pub(super) proposer: PublicKey,
+    pub(super) deploy_hashes: Vec<DeployHash>,
+    pub(super) transfer_hashes: Vec<DeployHash>,
+}
+
+impl BlockBodyV1 {
+    pub(crate) fn new(
+        proposer: PublicKey,
+        deploy_hashes: Vec<DeployHash>,
+        transfer_hashes: Vec<DeployHash>,
+    ) -> Self {
+        BlockBodyV1 {
+            proposer,
+            deploy_hashes,
+            transfer_hashes,
+        }
+    }
+}

--- a/types/src/legacy_sse_data/translate_block_added.rs
+++ b/types/src/legacy_sse_data/translate_block_added.rs
@@ -1,0 +1,159 @@
+use super::{
+    structs,
+    translate_deploy_hashes::{
+        DefaultDeployHashTranslator, DeployHashTranslator, TransferDeployHashTranslator,
+    },
+    LegacySseData,
+};
+use casper_types::{Block, BlockHash, BlockV2, EraEndV1, EraEndV2, EraReport, U512};
+use mockall::automock;
+use std::collections::BTreeMap;
+
+#[automock]
+pub trait BlockV2Translator {
+    fn translate(&self, block_v2: &BlockV2) -> Option<structs::BlockV1>;
+}
+
+#[automock]
+pub trait BlockAddedTranslator {
+    fn translate(&self, block_hash: &BlockHash, block: &Block) -> Option<LegacySseData>;
+}
+
+#[automock]
+pub trait EraEndV2Translator {
+    fn translate(&self, era_end_v2: &EraEndV2) -> Option<EraEndV1>;
+}
+
+#[derive(Default)]
+pub struct DefaultEraEndV2Translator;
+
+impl EraEndV2Translator for DefaultEraEndV2Translator {
+    fn translate(&self, era_end: &EraEndV2) -> Option<EraEndV1> {
+        let mut rewards = BTreeMap::new();
+        for (k, v) in era_end.rewards().iter() {
+            let max_u64 = U512::from(u64::MAX);
+            if v.gt(&max_u64) {
+                //We're not able to cast the reward to u64, so we skip this era end.
+                return None;
+            }
+            rewards.insert(k.clone(), v.as_u64());
+        }
+        let era_report = EraReport::new(
+            era_end.equivocators().to_vec(),
+            rewards,
+            era_end.inactive_validators().to_vec(),
+        );
+        Some(EraEndV1::new(
+            era_report,
+            era_end.next_era_validator_weights().clone(),
+        ))
+    }
+}
+
+pub struct DefaultBlockV2Translator<ET, DT, TT>
+where
+    ET: EraEndV2Translator,
+    DT: DeployHashTranslator,
+    TT: DeployHashTranslator,
+{
+    era_end_translator: ET,
+    deploy_hash_translator: DT,
+    transfer_hash_translator: TT,
+}
+
+impl<ET, DT, TT> BlockV2Translator for DefaultBlockV2Translator<ET, DT, TT>
+where
+    ET: EraEndV2Translator,
+    DT: DeployHashTranslator,
+    TT: DeployHashTranslator,
+{
+    fn translate(&self, block_v2: &BlockV2) -> Option<structs::BlockV1> {
+        let header = block_v2.header();
+        let parent_hash = *header.parent_hash();
+        let body_hash = *header.body_hash();
+        let state_root_hash = *header.state_root_hash();
+        let random_bit = block_v2.header().random_bit();
+        let accumulated_seed = *header.accumulated_seed();
+        let era_end = header
+            .era_end()
+            .and_then(|era_end| self.era_end_translator.translate(era_end));
+        let timestamp = block_v2.header().timestamp();
+        let era_id = block_v2.header().era_id();
+        let height = block_v2.header().height();
+        let protocol_version = block_v2.header().protocol_version();
+        let block_hash = block_v2.hash();
+        let body = block_v2.body();
+        let proposer = body.proposer().clone();
+        let deploy_hashes = self.deploy_hash_translator.translate(body);
+        let transfer_hashes = self.transfer_hash_translator.translate(body);
+        let block_v1 = structs::BlockV1::new(
+            parent_hash,
+            state_root_hash,
+            body_hash,
+            random_bit,
+            accumulated_seed,
+            era_end,
+            timestamp,
+            era_id,
+            height,
+            protocol_version,
+            proposer,
+            *block_hash,
+            deploy_hashes,
+            transfer_hashes,
+        );
+        Some(block_v1)
+    }
+}
+
+pub struct DefaultBlockAddedTranslator<BT>
+where
+    BT: BlockV2Translator,
+{
+    block_v2_translator: BT,
+}
+
+pub fn build_default_block_added_translator() -> DefaultBlockAddedTranslator<
+    DefaultBlockV2Translator<
+        DefaultEraEndV2Translator,
+        DefaultDeployHashTranslator,
+        TransferDeployHashTranslator,
+    >,
+> {
+    DefaultBlockAddedTranslator {
+        block_v2_translator: build_default_block_v2_translator(),
+    }
+}
+
+pub fn build_default_block_v2_translator() -> DefaultBlockV2Translator<
+    DefaultEraEndV2Translator,
+    DefaultDeployHashTranslator,
+    TransferDeployHashTranslator,
+> {
+    DefaultBlockV2Translator {
+        era_end_translator: DefaultEraEndV2Translator,
+        deploy_hash_translator: DefaultDeployHashTranslator,
+        transfer_hash_translator: TransferDeployHashTranslator,
+    }
+}
+
+impl<T> BlockAddedTranslator for DefaultBlockAddedTranslator<T>
+where
+    T: BlockV2Translator,
+{
+    fn translate(&self, block_hash: &BlockHash, block: &Block) -> Option<LegacySseData> {
+        match block {
+            Block::V1(block_v1) => Some(LegacySseData::BlockAdded {
+                block_hash: *block_hash,
+                block: structs::BlockV1::from(*block_v1.hash(), block_v1.header(), block_v1.body()),
+            }),
+            Block::V2(block_v2) => {
+                let maybe_block = self.block_v2_translator.translate(block_v2);
+                maybe_block.map(|block| LegacySseData::BlockAdded {
+                    block_hash: *block_hash,
+                    block,
+                })
+            }
+        }
+    }
+}

--- a/types/src/legacy_sse_data/translate_block_added.rs
+++ b/types/src/legacy_sse_data/translate_block_added.rs
@@ -1,7 +1,7 @@
 use super::{
     structs,
     translate_deploy_hashes::{
-        StandardDeployHashesTranslator, DeployHashTranslator, TransferDeployHashesTranslator,
+        DeployHashTranslator, StandardDeployHashesTranslator, TransferDeployHashesTranslator,
     },
     LegacySseData,
 };

--- a/types/src/legacy_sse_data/translate_block_added.rs
+++ b/types/src/legacy_sse_data/translate_block_added.rs
@@ -1,7 +1,7 @@
 use super::{
     structs,
     translate_deploy_hashes::{
-        DefaultDeployHashTranslator, DeployHashTranslator, TransferDeployHashTranslator,
+        StandardDeployHashesTranslator, DeployHashTranslator, TransferDeployHashesTranslator,
     },
     LegacySseData,
 };
@@ -116,8 +116,8 @@ where
 pub fn build_default_block_added_translator() -> DefaultBlockAddedTranslator<
     DefaultBlockV2Translator<
         DefaultEraEndV2Translator,
-        DefaultDeployHashTranslator,
-        TransferDeployHashTranslator,
+        StandardDeployHashesTranslator,
+        TransferDeployHashesTranslator,
     >,
 > {
     DefaultBlockAddedTranslator {
@@ -127,13 +127,13 @@ pub fn build_default_block_added_translator() -> DefaultBlockAddedTranslator<
 
 pub fn build_default_block_v2_translator() -> DefaultBlockV2Translator<
     DefaultEraEndV2Translator,
-    DefaultDeployHashTranslator,
-    TransferDeployHashTranslator,
+    StandardDeployHashesTranslator,
+    TransferDeployHashesTranslator,
 > {
     DefaultBlockV2Translator {
         era_end_translator: DefaultEraEndV2Translator,
-        deploy_hash_translator: DefaultDeployHashTranslator,
-        transfer_hash_translator: TransferDeployHashTranslator,
+        deploy_hash_translator: StandardDeployHashesTranslator,
+        transfer_hash_translator: TransferDeployHashesTranslator,
     }
 }
 

--- a/types/src/legacy_sse_data/translate_deploy_hashes.rs
+++ b/types/src/legacy_sse_data/translate_deploy_hashes.rs
@@ -1,0 +1,37 @@
+use casper_types::{BlockBodyV2, DeployHash, TransactionHash};
+use mockall::automock;
+
+#[automock]
+pub trait DeployHashTranslator {
+    fn translate(&self, block_body_v2: &BlockBodyV2) -> Vec<DeployHash>;
+}
+
+#[derive(Default)]
+pub struct DefaultDeployHashTranslator;
+
+#[derive(Default)]
+pub struct TransferDeployHashTranslator;
+
+impl DeployHashTranslator for DefaultDeployHashTranslator {
+    fn translate(&self, block_body_v2: &casper_types::BlockBodyV2) -> Vec<DeployHash> {
+        block_body_v2
+            .standard()
+            .filter_map(|el| match el {
+                TransactionHash::Deploy(deploy_hash) => Some(*deploy_hash),
+                TransactionHash::V1(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl DeployHashTranslator for TransferDeployHashTranslator {
+    fn translate(&self, block_body_v2: &casper_types::BlockBodyV2) -> Vec<DeployHash> {
+        block_body_v2
+            .mint()
+            .filter_map(|el| match el {
+                TransactionHash::Deploy(deploy_hash) => Some(*deploy_hash),
+                TransactionHash::V1(_) => None,
+            })
+            .collect()
+    }
+}

--- a/types/src/legacy_sse_data/translate_deploy_hashes.rs
+++ b/types/src/legacy_sse_data/translate_deploy_hashes.rs
@@ -7,12 +7,12 @@ pub trait DeployHashTranslator {
 }
 
 #[derive(Default)]
-pub struct DefaultDeployHashTranslator;
+pub struct StandardDeployHashesTranslator;
 
 #[derive(Default)]
-pub struct TransferDeployHashTranslator;
+pub struct TransferDeployHashesTranslator;
 
-impl DeployHashTranslator for DefaultDeployHashTranslator {
+impl DeployHashTranslator for StandardDeployHashesTranslator {
     fn translate(&self, block_body_v2: &casper_types::BlockBodyV2) -> Vec<DeployHash> {
         block_body_v2
             .standard()
@@ -24,7 +24,7 @@ impl DeployHashTranslator for DefaultDeployHashTranslator {
     }
 }
 
-impl DeployHashTranslator for TransferDeployHashTranslator {
+impl DeployHashTranslator for TransferDeployHashesTranslator {
     fn translate(&self, block_body_v2: &casper_types::BlockBodyV2) -> Vec<DeployHash> {
         block_body_v2
             .mint()

--- a/types/src/legacy_sse_data/translate_execution_result.rs
+++ b/types/src/legacy_sse_data/translate_execution_result.rs
@@ -1,0 +1,230 @@
+use casper_types::{
+    addressable_entity::NamedKeys,
+    execution::{
+        execution_result_v1::{ExecutionEffect, NamedKey, TransformKindV1, TransformV1},
+        Effects, ExecutionResultV1, ExecutionResultV2, TransformV2,
+    },
+    StoredValue,
+};
+
+pub fn build_default_execution_result_translator(
+) -> DefaultExecutionResultV2Translator<DefaultExecutionEffectsTranslator> {
+    DefaultExecutionResultV2Translator {
+        effects_translator: DefaultExecutionEffectsTranslator,
+    }
+}
+
+pub trait ExecutionResultV2Translator {
+    fn translate(&self, result: &ExecutionResultV2) -> Option<ExecutionResultV1>;
+}
+
+pub trait ExecutionEffectsTranslator {
+    fn translate(&self, effects: &Effects) -> Option<ExecutionEffect>;
+}
+
+pub struct DefaultExecutionResultV2Translator<EET>
+where
+    EET: ExecutionEffectsTranslator,
+{
+    effects_translator: EET,
+}
+
+impl<EET> ExecutionResultV2Translator for DefaultExecutionResultV2Translator<EET>
+where
+    EET: ExecutionEffectsTranslator,
+{
+    fn translate(&self, result: &ExecutionResultV2) -> Option<ExecutionResultV1> {
+        let maybe_effects = self.effects_translator.translate(&result.effects);
+        if let Some(effect) = maybe_effects {
+            if let Some(err_msg) = &result.error_message {
+                Some(ExecutionResultV1::Failure {
+                    effect,
+                    transfers: vec![],
+                    cost: result.cost,
+                    error_message: err_msg.to_string(),
+                })
+            } else {
+                Some(ExecutionResultV1::Success {
+                    effect,
+                    transfers: vec![],
+                    cost: result.cost,
+                })
+            }
+        } else {
+            None
+        }
+    }
+}
+
+pub struct DefaultExecutionEffectsTranslator;
+
+impl ExecutionEffectsTranslator for DefaultExecutionEffectsTranslator {
+    fn translate(&self, effects: &Effects) -> Option<ExecutionEffect> {
+        let mut transforms: Vec<TransformV1> = Vec::new();
+        for ex_ef in effects.transforms() {
+            let key = *ex_ef.key();
+            let maybe_transform_kind = map_transform_v2(ex_ef);
+            if let Some(transform_kind) = maybe_transform_kind {
+                let transform = TransformV1 {
+                    key: key.to_string(),
+                    transform: transform_kind,
+                };
+                transforms.push(transform);
+            } else {
+                // If we stumble on a transform we can't translate, we should clear all of them
+                // so that the user won't get a partial view of the effects.
+                transforms.clear();
+                break;
+            }
+        }
+        Some(ExecutionEffect {
+            // Operations will be empty since we can't translate them (no V2 entity has a corresponding entity in V1).
+            operations: vec![],
+            transforms,
+        })
+    }
+}
+
+fn map_transform_v2(ex_ef: &TransformV2) -> Option<TransformKindV1> {
+    let maybe_transform_kind = match ex_ef.kind() {
+        casper_types::execution::TransformKindV2::Identity => Some(TransformKindV1::Identity),
+        casper_types::execution::TransformKindV2::Write(stored_value) => {
+            maybe_tanslate_stored_value(stored_value)
+        }
+        casper_types::execution::TransformKindV2::AddInt32(v) => {
+            Some(TransformKindV1::AddInt32(*v))
+        }
+        casper_types::execution::TransformKindV2::AddUInt64(v) => {
+            Some(TransformKindV1::AddUInt64(*v))
+        }
+        casper_types::execution::TransformKindV2::AddUInt128(v) => {
+            Some(TransformKindV1::AddUInt128(*v))
+        }
+        casper_types::execution::TransformKindV2::AddUInt256(v) => {
+            Some(TransformKindV1::AddUInt256(*v))
+        }
+        casper_types::execution::TransformKindV2::AddUInt512(v) => {
+            Some(TransformKindV1::AddUInt512(*v))
+        }
+        casper_types::execution::TransformKindV2::AddKeys(keys) => handle_named_keys(keys),
+        casper_types::execution::TransformKindV2::Prune(key) => Some(TransformKindV1::Prune(*key)),
+        casper_types::execution::TransformKindV2::Failure(err) => {
+            Some(TransformKindV1::Failure(err.to_string()))
+        }
+    };
+    maybe_transform_kind
+}
+
+fn handle_named_keys(keys: &NamedKeys) -> Option<TransformKindV1> {
+    let mut named_keys = vec![];
+    for (name, key) in keys.iter() {
+        let named_key = NamedKey {
+            name: name.to_string(),
+            key: key.to_string(),
+        };
+        named_keys.push(named_key);
+    }
+    Some(TransformKindV1::AddKeys(named_keys))
+}
+
+fn maybe_tanslate_stored_value(stored_value: &StoredValue) -> Option<TransformKindV1> {
+    //TODO stored_value this shouldn't be a reference. we should take ownership and reassign to V1 enum to avoid potentially expensive clones.
+    match stored_value {
+        StoredValue::CLValue(cl_value) => Some(TransformKindV1::WriteCLValue(cl_value.clone())),
+        StoredValue::Account(acc) => Some(TransformKindV1::WriteAccount(acc.account_hash())),
+        StoredValue::ContractWasm(_) => Some(TransformKindV1::WriteContractWasm),
+        StoredValue::Contract(_) => Some(TransformKindV1::WriteContract),
+        StoredValue::ContractPackage(_) => Some(TransformKindV1::WriteContractPackage),
+        StoredValue::LegacyTransfer(transfer) => {
+            Some(TransformKindV1::WriteTransfer(transfer.clone()))
+        }
+        StoredValue::DeployInfo(deploy_info) => {
+            Some(TransformKindV1::WriteDeployInfo(deploy_info.clone()))
+        }
+        StoredValue::EraInfo(era_info) => Some(TransformKindV1::WriteEraInfo(era_info.clone())),
+        StoredValue::Bid(bid) => Some(TransformKindV1::WriteBid(bid.clone())),
+        StoredValue::Withdraw(withdraw) => Some(TransformKindV1::WriteWithdraw(withdraw.clone())),
+        StoredValue::Unbonding(p) => Some(TransformKindV1::WriteUnbonding(p.clone())),
+        StoredValue::NamedKey(named_key) => {
+            let key_res = named_key.get_key();
+            let name_res = named_key.get_name();
+            if let (Ok(key), Ok(name)) = (key_res, name_res) {
+                Some(TransformKindV1::AddKeys(vec![NamedKey {
+                    name: name.to_string(),
+                    key: key.to_string(),
+                }]))
+            } else {
+                None
+            }
+        }
+        // following variuant will not be understood by old clients since they are introduced in 2.x
+        StoredValue::AddressableEntity(_) => None,
+        StoredValue::BidKind(_) => None,
+        StoredValue::Package(_) => None,
+        StoredValue::ByteCode(_) => None,
+        StoredValue::MessageTopic(_) => None,
+        StoredValue::Message(_) => None,
+        StoredValue::Reservation(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::maybe_tanslate_stored_value;
+    use casper_types::{
+        account::{AccountHash, ActionThresholds, AssociatedKeys, Weight},
+        addressable_entity::NamedKeys,
+        contracts::{ContractPackage, ContractPackageStatus, ContractVersions, DisabledVersions},
+        execution::execution_result_v1::TransformKindV1,
+        AccessRights, Account, CLValue, Groups, StoredValue, URef,
+    };
+
+    #[test]
+    fn maybe_tanslate_stored_value_should_translate_values() {
+        let stored_value = StoredValue::CLValue(CLValue::from_t(1).unwrap());
+        assert_eq!(
+            Some(TransformKindV1::WriteCLValue(CLValue::from_t(1).unwrap())),
+            maybe_tanslate_stored_value(&stored_value)
+        );
+
+        let account = random_account();
+        let stored_value = StoredValue::Account(account);
+        assert_eq!(
+            Some(TransformKindV1::WriteAccount(AccountHash::new([9u8; 32]))),
+            maybe_tanslate_stored_value(&stored_value)
+        );
+
+        let contract_package = random_contract_package();
+        let stored_value = StoredValue::ContractPackage(contract_package);
+        assert_eq!(
+            Some(TransformKindV1::WriteContractPackage),
+            maybe_tanslate_stored_value(&stored_value)
+        );
+        //TODO wrtite tests for rest of cases
+    }
+
+    fn random_account() -> Account {
+        let account_hash = AccountHash::new([9u8; 32]);
+        let action_thresholds = ActionThresholds {
+            deployment: Weight::new(8),
+            key_management: Weight::new(11),
+        };
+        Account::new(
+            account_hash,
+            NamedKeys::default(),
+            URef::new([43; 32], AccessRights::READ_ADD_WRITE),
+            AssociatedKeys::default(),
+            action_thresholds,
+        )
+    }
+
+    fn random_contract_package() -> ContractPackage {
+        ContractPackage::new(
+            URef::new([0; 32], AccessRights::NONE),
+            ContractVersions::default(),
+            DisabledVersions::default(),
+            Groups::default(),
+            ContractPackageStatus::default(),
+        )
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -5,6 +5,7 @@
 #[cfg_attr(not(test), macro_use)]
 extern crate alloc;
 mod filter;
+pub mod legacy_sse_data;
 pub mod sse_data;
 #[cfg(feature = "sse-data-testing")]
 mod testing;

--- a/types/src/sse_data.rs
+++ b/types/src/sse_data.rs
@@ -269,7 +269,7 @@ pub mod test_support {
     }
 
     pub fn example_finality_signature_2_0_0(hash: &str) -> String {
-        let raw_block_added = format!("{{\"FinalitySignature\":{{\"block_hash\":\"{hash}\",\"era_id\":2,\"signature\":\"01ff6089c9b187f38ba61b518082db22552fb4762d505773e8221f6593c45e0602de560c4690b035dbacba9ab9dbe63e97d928970a515ea6a25fb920b3e9099d05\",\"public_key\":\"01914182c7d11ef13dccdbf1470648af3c3cd7f570bc351f0c14112370b19b8331\"}}}}");
+        let raw_block_added = format!("{{\"FinalitySignature\":{{\"V2\":{{\"block_hash\":\"{hash}\",\"block_height\":123026,\"era_id\":279,\"chain_name_hash\":\"f087a92e6e7077b3deb5e00b14a904e34c7068a9410365435bc7ca5d3ac64301\",\"signature\":\"01f2e7303a064d68b83d438c55056db2e32eda973f24c548176ac654580f0a6ef8b8b4ce7758bcee6f889bc5d4a653b107d6d4c9f5f20701c08259ece28095a10d\",\"public_key\":\"0126d4637eb0c0769274f03a696df1112383fa621c9f73f57af4c5c0fbadafa8cf\"}}}}}}");
         super::deserialize(&raw_block_added).unwrap(); // deserializing to make sure that the raw json string is in correct form
         raw_block_added
     }


### PR DESCRIPTION
Added mapping from V2 firehose `/events` sse endpoint to V1 compatible events split into filters