### PR TITLE
Point casper-node dependency back at the main repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/rafal-ch/casper-node?branch=julietless_node_2#33415a5a0b26757ac21ce62a457d8481940904e1"
+source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#44e99ef830a7de6bd7e61faf2c6dadd6d9b06d08"
 dependencies = [
  "bincode",
  "bytes",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/rafal-ch/casper-node?branch=julietless_node_2#33415a5a0b26757ac21ce62a457d8481940904e1"
+source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#44e99ef830a7de6bd7e61faf2c6dadd6d9b06d08"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [
 anyhow = "1"
 async-stream = "0.3.4"
 async-trait = "0.1.77"
-casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "julietless_node_2" }
-casper-binary-port = { git = "https://github.com/rafal-ch/casper-node", branch = "julietless_node_2" }
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "feat-2.0" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch = "feat-2.0" }
 casper-event-sidecar = { path = "./event_sidecar", version = "1.0.0" }
 casper-event-types = { path = "./types", version = "1.0.0" }
 casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }


### PR DESCRIPTION
The dependency was temporarily pointed at a fork to avoid breaking the drone build in casper-node, it can now be changed back