### PR TITLE
Balance cleanup

### DIFF
--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -1210,7 +1210,7 @@
             "description": "The identifier for the state used for the query, if none is passed, the latest block will be used.",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/BalanceStateIdentifier"
+                "$ref": "#/components/schemas/GlobalStateIdentifier"
               },
               {
                 "type": "null"
@@ -1266,9 +1266,7 @@
             {
               "name": "state_identifier",
               "value": {
-                "block": {
-                  "Hash": "0707070707070707070707070707070707070707070707070707070707070707"
-                }
+                "BlockHash": "0707070707070707070707070707070707070707070707070707070707070707"
               }
             },
             {
@@ -2034,7 +2032,7 @@
               "type": "string"
             },
             "balance_value": {
-              "description": "The available balance in motes (total balance - sum of all active holds). The active holds are determined by the current timestamp and not the state root hash. If you need to account for holds at a specific time, you should use the `query_balance_details` RPC.",
+              "description": "The available balance in motes (total balance - sum of all active holds).",
               "$ref": "#/components/schemas/U512"
             },
             "merkle_proof": {
@@ -7235,60 +7233,6 @@
             "properties": {
               "purse_uref": {
                 "$ref": "#/components/schemas/URef"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
-      "BalanceStateIdentifier": {
-        "description": "Identifier of a balance.",
-        "oneOf": [
-          {
-            "description": "The balance at a specific block.",
-            "type": "object",
-            "required": [
-              "block"
-            ],
-            "properties": {
-              "block": {
-                "$ref": "#/components/schemas/BlockIdentifier"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "The balance at a specific state root.",
-            "type": "object",
-            "required": [
-              "state_root"
-            ],
-            "properties": {
-              "state_root": {
-                "type": "object",
-                "required": [
-                  "state_root_hash",
-                  "timestamp"
-                ],
-                "properties": {
-                  "state_root_hash": {
-                    "description": "The state root hash.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/Digest"
-                      }
-                    ]
-                  },
-                  "timestamp": {
-                    "description": "Timestamp for holds lookup.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/Timestamp"
-                      }
-                    ]
-                  }
-                },
-                "additionalProperties": false
               }
             },
             "additionalProperties": false

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -22,7 +22,7 @@ use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     AvailableBlockRange, BlockHash, BlockHeader, BlockIdentifier, ChainspecRawBytes, Digest,
     GlobalStateIdentifier, Key, KeyTag, Peers, ProtocolVersion, SignedBlock, StoredValue,
-    Timestamp, Transaction, TransactionHash, Transfer,
+    Transaction, TransactionHash, Transfer,
 };
 use std::{
     fmt::{self, Display, Formatter},
@@ -91,25 +91,9 @@ pub trait NodeClient: Send + Sync {
         &self,
         state_identifier: Option<GlobalStateIdentifier>,
         purse_identifier: PurseIdentifier,
-        _timestamp: Timestamp,
     ) -> Result<BalanceResponse, Error> {
         let get = GlobalStateRequest::BalanceByStateRoot {
             state_identifier,
-            purse_identifier,
-        };
-        let resp = self
-            .send_request(BinaryRequest::Get(GetRequest::State(Box::new(get))))
-            .await?;
-        parse_response::<BalanceResponse>(&resp.into())?.ok_or(Error::EmptyEnvelope)
-    }
-
-    async fn get_balance_by_block(
-        &self,
-        block_identifier: Option<BlockIdentifier>,
-        purse_identifier: PurseIdentifier,
-    ) -> Result<BalanceResponse, Error> {
-        let get = GlobalStateRequest::BalanceByBlock {
-            block_identifier,
             purse_identifier,
         };
         let resp = self


### PR DESCRIPTION
After balance changes in the node, we can now get rid of a `Timestamp::now` hack that was necessary due to the node requiring the timestamp in the balance request. The timestamp is now automatically looked up in the node.

I've also changed the format of the request to use `GlobalStateIdentifier` to further simplify, because we no longer need a separate model for `BalanceStateIdentifier`.