### PR TITLE
Update casper node dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#897332af35f0fcfa78489c23df56f8402e1bb745"
+source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#73178683865ec0353a9bbae50b1ef1e81bf07f1f"
 dependencies = [
  "bincode",
  "bytes",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#897332af35f0fcfa78489c23df56f8402e1bb745"
+source = "git+https://github.com/casper-network/casper-node?branch=feat-2.0#73178683865ec0353a9bbae50b1ef1e81bf07f1f"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -3554,6 +3554,13 @@
             "enum": [
               "ActivateBid"
             ]
+          },
+          {
+            "description": "The `change_bid_public_key` native entry point, used to change a bid's public key.",
+            "type": "string",
+            "enum": [
+              "ChangeBidPublicKey"
+            ]
           }
         ]
       },
@@ -4794,6 +4801,19 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "A bridge record pointing to a new `ValidatorBid` after the public key was changed.",
+            "type": "object",
+            "required": [
+              "Bridge"
+            ],
+            "properties": {
+              "Bridge": {
+                "$ref": "#/components/schemas/Bridge"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -4852,6 +4872,42 @@
           "inactive": {
             "description": "`true` if validator has been \"evicted\"",
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Bridge": {
+        "description": "A bridge record pointing to a new `ValidatorBid` after the public key was changed.",
+        "type": "object",
+        "required": [
+          "era_id",
+          "new_validator_public_key",
+          "old_validator_public_key"
+        ],
+        "properties": {
+          "old_validator_public_key": {
+            "description": "Previous validator public key associated with the bid.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "new_validator_public_key": {
+            "description": "New validator public key associated with the bid.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "era_id": {
+            "description": "Era when bridge record was created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EraId"
+              }
+            ]
           }
         },
         "additionalProperties": false

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -2876,6 +2876,19 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "A bridge record pointing to a new `ValidatorBid` after the public key was changed.",
+            "type": "object",
+            "required": [
+              "Bridge"
+            ],
+            "properties": {
+              "Bridge": {
+                "$ref": "#/components/schemas/Bridge"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -2934,6 +2947,42 @@
           "inactive": {
             "description": "`true` if validator has been \"evicted\"",
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Bridge": {
+        "description": "A bridge record pointing to a new `ValidatorBid` after the public key was changed.",
+        "type": "object",
+        "required": [
+          "era_id",
+          "new_validator_public_key",
+          "old_validator_public_key"
+        ],
+        "properties": {
+          "old_validator_public_key": {
+            "description": "Previous validator public key associated with the bid.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "new_validator_public_key": {
+            "description": "New validator public key associated with the bid.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "era_id": {
+            "description": "Era when bridge record was created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EraId"
+              }
+            ]
           }
         },
         "additionalProperties": false
@@ -3890,6 +3939,13 @@
             "type": "string",
             "enum": [
               "ActivateBid"
+            ]
+          },
+          {
+            "description": "The `change_bid_public_key` native entry point, used to change a bid's public key.",
+            "type": "string",
+            "enum": [
+              "ChangeBidPublicKey"
             ]
           }
         ]

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -87,7 +87,7 @@ pub trait NodeClient: Send + Sync {
         parse_response::<Vec<StoredValue>>(&resp.into())?.ok_or(Error::EmptyEnvelope)
     }
 
-    async fn get_balance(
+    async fn read_balance(
         &self,
         state_identifier: Option<GlobalStateIdentifier>,
         purse_identifier: PurseIdentifier,

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -87,12 +87,12 @@ pub trait NodeClient: Send + Sync {
         parse_response::<Vec<StoredValue>>(&resp.into())?.ok_or(Error::EmptyEnvelope)
     }
 
-    async fn get_balance_by_state_root(
+    async fn get_balance(
         &self,
         state_identifier: Option<GlobalStateIdentifier>,
         purse_identifier: PurseIdentifier,
     ) -> Result<BalanceResponse, Error> {
-        let get = GlobalStateRequest::BalanceByStateRoot {
+        let get = GlobalStateRequest::Balance {
             state_identifier,
             purse_identifier,
         };

--- a/rpc_sidecar/src/rpcs/state.rs
+++ b/rpc_sidecar/src/rpcs/state.rs
@@ -277,7 +277,7 @@ impl RpcWithParams for GetBalance {
         let state_id = GlobalStateIdentifier::StateRootHash(params.state_root_hash);
         let purse_id = PortPurseIdentifier::Purse(purse_uref);
         let balance = node_client
-            .get_balance_by_state_root(Some(state_id), purse_id)
+            .get_balance(Some(state_id), purse_id)
             .await
             .map_err(|err| Error::NodeRequest("balance", err))?;
 
@@ -934,7 +934,7 @@ impl RpcWithParams for QueryBalance {
     ) -> Result<Self::ResponseResult, RpcError> {
         let purse_id = params.purse_identifier.into_port_purse_identifier();
         let balance = node_client
-            .get_balance_by_state_root(params.state_identifier, purse_id)
+            .get_balance(params.state_identifier, purse_id)
             .await
             .map_err(|err| Error::NodeRequest("balance by state root", err))?;
         Ok(Self::ResponseResult {
@@ -1007,7 +1007,7 @@ impl RpcWithParams for QueryBalanceDetails {
     ) -> Result<Self::ResponseResult, RpcError> {
         let purse_id = params.purse_identifier.into_port_purse_identifier();
         let balance = node_client
-            .get_balance_by_state_root(params.state_identifier, purse_id)
+            .get_balance(params.state_identifier, purse_id)
             .await
             .map_err(|err| Error::NodeRequest("balance by state root", err))?;
 
@@ -2040,11 +2040,7 @@ mod tests {
         ) -> Result<BinaryResponseAndRequest, ClientError> {
             match req {
                 BinaryRequest::Get(GetRequest::State(req))
-                    if matches!(
-                        &*req,
-                        GlobalStateRequest::BalanceByBlock { .. }
-                            | GlobalStateRequest::BalanceByStateRoot { .. }
-                    ) =>
+                    if matches!(&*req, GlobalStateRequest::Balance { .. }) =>
                 {
                     Ok(BinaryResponseAndRequest::new(
                         BinaryResponse::from_value(self.0.clone(), SUPPORTED_PROTOCOL_VERSION),

--- a/rpc_sidecar/src/rpcs/state.rs
+++ b/rpc_sidecar/src/rpcs/state.rs
@@ -277,7 +277,7 @@ impl RpcWithParams for GetBalance {
         let state_id = GlobalStateIdentifier::StateRootHash(params.state_root_hash);
         let purse_id = PortPurseIdentifier::Purse(purse_uref);
         let balance = node_client
-            .get_balance(Some(state_id), purse_id)
+            .read_balance(Some(state_id), purse_id)
             .await
             .map_err(|err| Error::NodeRequest("balance", err))?;
 
@@ -934,7 +934,7 @@ impl RpcWithParams for QueryBalance {
     ) -> Result<Self::ResponseResult, RpcError> {
         let purse_id = params.purse_identifier.into_port_purse_identifier();
         let balance = node_client
-            .get_balance(params.state_identifier, purse_id)
+            .read_balance(params.state_identifier, purse_id)
             .await
             .map_err(|err| Error::NodeRequest("balance by state root", err))?;
         Ok(Self::ResponseResult {
@@ -1007,7 +1007,7 @@ impl RpcWithParams for QueryBalanceDetails {
     ) -> Result<Self::ResponseResult, RpcError> {
         let purse_id = params.purse_identifier.into_port_purse_identifier();
         let balance = node_client
-            .get_balance(params.state_identifier, purse_id)
+            .read_balance(params.state_identifier, purse_id)
             .await
             .map_err(|err| Error::NodeRequest("balance by state root", err))?;
 

--- a/rpc_sidecar/src/rpcs/state.rs
+++ b/rpc_sidecar/src/rpcs/state.rs
@@ -936,7 +936,7 @@ impl RpcWithParams for QueryBalance {
         let balance = node_client
             .read_balance(params.state_identifier, purse_id)
             .await
-            .map_err(|err| Error::NodeRequest("balance by state root", err))?;
+            .map_err(|err| Error::NodeRequest("balance", err))?;
         Ok(Self::ResponseResult {
             api_version: CURRENT_API_VERSION,
             balance: balance.available_balance,
@@ -1009,7 +1009,7 @@ impl RpcWithParams for QueryBalanceDetails {
         let balance = node_client
             .read_balance(params.state_identifier, purse_id)
             .await
-            .map_err(|err| Error::NodeRequest("balance by state root", err))?;
+            .map_err(|err| Error::NodeRequest("balance", err))?;
 
         let holds = balance
             .balance_holds


### PR DESCRIPTION
An update to align with a binary port change: https://github.com/casper-network/casper-node/pull/4690.
Also updates the schema files.