### PR TITLE
805 - Update the READMEs and config.toml example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,14 @@ The SSE Listener processes events in this order:
 2. Store the event.
 3. Publish the event to the SSE API.
 
-Casper nodes stream server-sent events with JSON-encoded data to the Sidecar. The Sidecar reads the event stream of all connected nodes, acting as a passthrough and replicating the SSE interface of the connected nodes. Enabling and configuring the SSE Server of the Sidecar is optional.
+Casper nodes offer an event stream API that returns server-sent events (SSEs) with JSON-encoded data. The Sidecar reads the event stream of all connected nodes, acting as a passthrough and replicating the SSE interface of the connected nodes. The Sidecar can:
 
 The Sidecar can:
 * Republish the current events from the node to clients listening to Sidecar's SSE API.
-* Publish a configurable number of previous events to clients connecting to the Sidecar's SSE API with `?start_from=` query.
+* Publish a configurable number of previous events to clients connecting to the Sidecar's SSE API with `?start_from=` query (similar to the node's SSE API).
 * Store the events in external storage for clients to query them via the Sidecar's REST API.
 
+Enabling and configuring the SSE Server of the Sidecar is optional.
 
 ### The REST API server
 
@@ -263,7 +264,6 @@ emulate_legacy_sse_apis = ["V1"]
 
 #### Configuring SSE node connections
 
-<!--TODO check if this needs to be reworded -->
 The Sidecar's SSE component can connect to Casper nodes' SSE endpoints with versions greater or equal to `2.0.0`.
 
 The `node_connections` option configures the node (or multiple nodes) to which the Sidecar will connect and the parameters under which it will operate with that node. Connecting to multiple nodes requires multiple `[[sse_server.connections]]` sections.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
-# Casper Event Sidecar README
+# The Casper Sidecar
 
 ## Summary of Purpose
 
-The Casper Event Sidecar is an application that runs in tandem with the node process. It's main purpose is to:
-* offload the node from broadcasting SSE events to multiple clients
-* provide client features that aren't part of the nodes' functionality, nor should they be
+The Casper Sidecar application runs in tandem with the node process, and its primary purpose is to:
+* Offload the node from broadcasting SSE events to multiple clients.
+* Provide client features that aren't part of the nodes' functionality, nor should they be.
 
 While the primary use case for the Sidecar application is running alongside the node on the same machine, it can be run remotely if necessary.
 
-### System Components & Architecture
+## System Components & Architecture
 
-Casper Sidecar has three main functionalities:
-* Providing a SSE server with a firehose `/events` endpoint that streams all events from the connected nodes. Sidecar also stores observed events in storage.
-* Providing a REST API server that allows clients to query events in storage.
-* Be a JSON RPC bridge between end users and a Casper node's binary RPC port.
+The Casper Sidecar provides the following functionalities:
+* A server-sent events (SSE) server with an `/events` endpoint that streams all the events received from all connected nodes. The Sidecar also stores these events.
+* A REST API server that allows clients to query stored events.
+* A JSON RPC bridge between end users and a Casper node's binary port.
 
-The system has the following components and external dependencies:
+The Sidecar has the following components and external dependencies:
+
 ```mermaid
    graph LR;
    subgraph CASPER-SIDECAR
@@ -35,9 +36,10 @@ The system has the following components and external dependencies:
    STORAGE --> REST_API
 ```
 
-#### SSE Server
+### The SSE server
 
-Diving into the SSE Server, we see the following components:
+The SSE Server has these components:
+
 ```mermaid
    graph TD;
    CLIENT{Client}
@@ -48,7 +50,7 @@ Diving into the SSE Server, we see the following components:
    NODE_SSE{Node SSE port}
    SSE_LISTENER --2--> STORAGE
    NODE_SSE --1--> SSE_LISTENER
-   subgraph "Casper sidecar"
+   subgraph "Casper Sidecar"
      MAIN[main.rs]
      MAIN --2.spawns---> SSE-SERVER
      subgraph SSE-SERVER
@@ -63,19 +65,23 @@ Diving into the SSE Server, we see the following components:
    end
 ```
 
-Given the flow above, the SSE Listener processes events in this order:
-1. Fetch an event from the node's SSE port
-2. Store the event
-3. Publish the event to the SSE API
+The SSE Listener processes events in this order:
+1. Fetch an event from the node's SSE port.
+2. Store the event.
+3. Publish the event to the SSE API.
+
+Casper nodes stream server-sent events with JSON-encoded data to the Sidecar. The Sidecar reads the event stream of all connected nodes, acting as a passthrough and replicating the SSE interface of the connected nodes. Enabling and configuring the SSE Server of the Sidecar is optional.
+
+The Sidecar can:
+* Republish the current events from the node to clients listening to Sidecar's SSE API.
+* Publish a configurable number of previous events to clients connecting to the Sidecar's SSE API with `?start_from=` query.
+* Store the events in external storage for clients to query them via the Sidecar's REST API.
 
 
-Casper nodes offer an event stream API that returns Server-Sent Events (SSEs) with JSON-encoded data. The Sidecar reads the event stream of all connected nodes, acting as a passthrough and replicating the SSE interface of the connected nodes. The Sidecar can:
-* republish the current events from the node to clients listening to Sidecar's SSE API
-* publish a configurable number of previous events to clients connecting to the Sidecar's SSE API with `?start_from=` query (similar to the node's SSE API)
-* store the events in external storage for clients to query them via the Sidecar's REST API
-Enabling and configuring the SSE Server of the Sidecar is optional. 
+### The REST API server
 
-#### REST API Server
+The Sidecar offers an optional REST API that allows clients to query the events stored in external storage. Node operators can discover the specific endpoints of the REST API using [OpenAPI] (#openapi-specification) and [Swagger] (#swagger-documentation). The [usage instructions](USAGE.md) provide more details.
+
 ```mermaid
    graph LR;
    CLIENT{Client}
@@ -84,32 +90,34 @@ Enabling and configuring the SSE Server of the Sidecar is optional.
    REST_API --> STORAGE
    CONFIG{{"Config file (toml)"}}
    MAIN --1.reads--> CONFIG
-   subgraph "Casper sidecar"
+   subgraph "Casper Sidecar"
       MAIN[main.rs]
       MAIN --2.spawns--> REST_API
       REST_API["REST API"]
    end
 ```
 
-The Sidecar offers an optional REST API that allows clients to query the events stored in external storage. Node operators can discover the specific endpoints of the REST API using [OpenAPI] (#openapi-specification) and [Swagger] (#swagger-documentation). Also, the [usage instructions](USAGE.md) provide more details.
+### The Admin API server
 
-#### ADMIN API Server
+The Sidecar offers an administrative API to allow an operator to check its current status. The Sidecar operator has the option to enable and configure this API. Please see the [admin server configuration](#admin-server) for details.
+
 ```mermaid
    graph LR;
    CLIENT{Client}
    CLIENT --> ADMIN_API
    CONFIG{{Config file}}
    MAIN --1.reads--> CONFIG
-   subgraph "Casper sidecar"
+   subgraph "Casper Sidecar"
       MAIN[main.rs]
       MAIN --2.spawns--> ADMIN_API
       ADMIN_API["ADMIN API"]
    end
 ```
 
-The Sidecar offers an administrative API to allow an operator to check its current status. The Sidecar operator has the option to enable and configure this API. Please see the [admin server configuration](#admin-server) for details.
+### The RPC API server
 
-#### RPC API Server
+The Sidecar also offers an RPC JSON API server that can be enabled and configured so that clients can interact with a Casper network. It is a JSON bridge between end users and a Casper node's binary port. The RPC API server forwards requests to the Casper node's binary port. For more details on how the RPC JSON API works, see the [RPC Sidecar README](rpc_sidecar/README.md).
+
 ```mermaid
    graph LR;
    CLIENT{Client}
@@ -118,15 +126,40 @@ The Sidecar offers an administrative API to allow an operator to check its curre
    MAIN --1.reads--> CONFIG
    CASPER_NODE(("Casper Node binary port"))
    RPC_API --forwards request--> CASPER_NODE
-   subgraph "Casper sidecar"
+   subgraph "Casper Sidecar"
       MAIN[main.rs]
       MAIN --2.spawns--> RPC_API
       RPC_API["RPC JSON API"]
    end
 ```
-The Sidecar offers an optional RPC JSON API module that can be enabled and configured. It is a JSON bridge between end users and a Casper node's binary port. The RPC API server forwards requests to the Casper node's binary port. For more details on how the RPC JSON API works, see the [RPC Sidecar README](rpc_sidecar/README.md).
 
-Here is an example configuration of the RPC API server:
+## Running and Testing the Sidecar
+
+## Prerequisites
+
+To compile, test, and run the Sidecar, install the following software first:
+
+* CMake 3.1.4 or greater
+* [Rust](https://www.rust-lang.org/tools/install)
+* pkg-config
+* gcc
+* g++
+
+## Configuration
+
+The Sidecar service must be configured using a `.toml` file specified at runtime.
+
+This repository contains several sample configuration files that can be used as examples and adjusted according to your scenario:
+
+- [EXAMPLE_NCTL_CONFIG.toml](./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml) - Configuration for connecting to nodes on a local NCTL network. This configuration is used in the unit and integration tests found in this repository.
+- [EXAMPLE_NCTL_POSTGRES_CONFIG.toml](./resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml) - Configuration for using the PostgreSQL database and nodes on a local NCTL network.
+- [EXAMPLE_NODE_CONFIG.toml](./resources/example_configs/EXAMPLE_NODE_CONFIG.toml) - Configuration for connecting to live nodes on a Casper network.
+
+Once you create the configuration file and are ready to run the Sidecar service, you must provide the configuration as an argument using the `-- --path-to-config` option as described [here](#running-the-sidecar).
+
+### Configuring the RPC server
+
+Here is an example configuration for the RPC API server:
 
 ```
 [rpc_server.main_server]
@@ -137,10 +170,12 @@ max_body_bytes = 2_621_440
 cors_origin = ''
 
 [rpc_server.node_client]
-address = '127.0.0.1:28101'
+address = '0.0.0.0:28101'
 max_message_size_bytes = 4_194_304
 request_limit = 3
 request_buffer_size = 16
+message_timeout_secs = 30
+client_access_timeout_secs = 2
 
 [rpc_server.speculative_exec_server]
 enable_server = true
@@ -169,43 +204,27 @@ max_attempts = 30
 * `speculative_exec_server.max_body_bytes` - Maximum body size of request to API in bytes.
 * `speculative_exec_server.cors_origin` - Configures the CORS origin.
 
-* `node_client.address` - Address of the Casper Node binary port
+* `node_client.address` - Address of the Casper Node binary port.
 * `node_client.max_message_size_bytes` - Maximum binary port message size in bytes.
 * `node_client.request_limit` - Maximum number of in-flight requests.
 * `node_client.request_buffer_size` - Number of node requests that can be buffered.
+* `node_client.message_timeout_secs` - Timeout for the message.
+* `node_client.client_access_timeout_secs` - Timeout for the client connection.
 
 * `node_client.exponential_backoff.initial_delay_ms` - Timeout after the first broken connection (backoff) in milliseconds.
 * `node_client.exponential_backoff.max_delay_ms` - Maximum timeout after a broken connection in milliseconds.
 * `node_client.exponential_backoff.coefficient` - Coefficient for the exponential backoff. The next timeout is calculated as min(`current_timeout * coefficient`, `max_delay_ms`).
 * `node_client.exponential_backoff.max_attempts` - Maximum number of times to try to reconnect to the binary port of the node.
 
-## Prerequisites
-
-* CMake 3.1.4 or greater
-* [Rust](https://www.rust-lang.org/tools/install)
-* pkg-config
-* gcc
-* g++
-
-## Configuration
-
-The SSE Sidecar service must be configured using a `.toml` file specified at runtime.
-
-This repository contains several sample configuration files that can be used as examples and adjusted according to your scenario:
-
-- [EXAMPLE_NCTL_CONFIG.toml](./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml) - Configuration for connecting to nodes on a local NCTL network. This configuration is used in the unit and integration tests found in this repository
-- [EXAMPLE_NCTL_POSTGRES_CONFIG.toml](./resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml) - Configuration for using the PostgreSQL database and nodes on a local NCTL network
-- [EXAMPLE_NODE_CONFIG.toml](./resources/example_configs/EXAMPLE_NODE_CONFIG.toml) - Configuration for connecting to live nodes on a Casper network and setting up an admin server    
-
-Once you create the configuration file and are ready to run the Sidecar service, you must provide the configuration as an argument using the `-- --path-to-config` option as described [here](#running-the-sidecar).
-
 ### SSE server configuration
-The Casper sidecar SSE server is used to connect to casper nodes, listen to events from them, store them locally and re-broadcast them to clients. The configuration for the SSE server itself is as follows:
+
+The Sidecar SSE server is used to connect to Casper nodes, listen to events from them, store them locally and re-broadcast them to clients. Here is a sample configuration for the SSE server:
 
 ```
 [sse_server]
 enable_server = true
 emulate_legacy_sse_apis = ["V1"]
+
 [[sse_server.connections]]
  <Described later in the document>
 
@@ -214,15 +233,19 @@ emulate_legacy_sse_apis = ["V1"]
 ```
 
 * `sse_server.enable_server` - If set to true, the SSE server will be enabled.
-* `sse_server.emulate_legacy_sse_apis` - A list of legacy casper node SSE APIs to emulate. The Sidecar will expose sse endpoints that are compatible with specified versions. Please bear in mind that this feature is an emulation and should be used only for transition periods. In most case scenarios having a 1 to 1 mapping of new messages into old formats is impossible, so this can be a process that looses some data and/or doesn't emit all messages that come out of the casper node. The details of the emulation are described in section [Event Stream Server SSE legacy emulations](#event-stream-server-sse-legacy-emulations) module.
+* `sse_server.emulate_legacy_sse_apis` - A list of legacy Casper node SSE APIs to emulate. The Sidecar will expose SSE endpoints that are compatible with specified versions. Please bear in mind that this feature is an emulation and should be used only for transition periods. In most scenarios, having a 1-to-1 mapping of new messages into old formats is impossible, so this can be a process that loses some data and/or doesn't emit all messages that come from the Casper node. <!--TODO link to new document The details of the emulation are described in the [Event Stream Server SSE legacy emulations](#event-stream-server-sse-legacy-emulations) section.-->
 
-#### SSE Node Connections
+#### SSE node connections
 
-The Casper Sidecar's SSE component can connect to Casper nodes' SSE endpoints with versions greater or equal to `2.0.0`.
+<!--TODO check if this needs to be reworded -->
+The Sidecar's SSE component can connect to Casper nodes' SSE endpoints with versions greater or equal to `2.0.0`.
 
 The `node_connections` option configures the node (or multiple nodes) to which the Sidecar will connect and the parameters under which it will operate with that node. Connecting to multiple nodes requires multiple `[[sse_server.connections]]` sections.
 
 ```
+[sse_server]
+enable_server = true
+
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
 sse_port = 18101
@@ -267,43 +290,77 @@ sleep_between_keep_alive_checks_in_seconds = 30
 * `delay_between_retries_in_seconds` - The delay between attempts to connect to the node.
 * `allow_partial_connection` - Determining whether the Sidecar will allow a partial connection to this node.
 * `enable_logging` - This enables the logging of events from the node in question.
-* `connection_timeout_in_seconds` - Number of seconds before the connection request times out. Parameter is optional, defaults to 5
-* `no_message_timeout_in_seconds` - Number of seconds after which the connection will be restarted if no bytes were received. Parameter is optional, defaults to 120
-* `sleep_between_keep_alive_checks_in_seconds` - Optional parameter specifying the time intervals (in seconds) for checking if the connection is still alive. Defaults to 60
+* `connection_timeout_in_seconds` - Number of seconds before the connection request times out. This parameter is optional, and defaults to 5.
+* `no_message_timeout_in_seconds` - Number of seconds after which the connection will be restarted if no bytes were received. This parameter is optional, and defaults to 120.
+* `sleep_between_keep_alive_checks_in_seconds` - Optional parameter specifying the time intervals (in seconds) for checking if the connection is still alive. Defaults to 60.
 
-#### Event Stream Server SSE legacy emulations
+#### SSE legacy emulations
 
-Currently the only possible emulation is the V1 SSE API. Enabling V1 SSE api emulation requires setting `emulate_legacy_sse_apis` to `["V1"]`, like:
+Applications using version 1 of a Casper node's event stream server can still function using an emulated V1 SSE API for a limited time. Enabling the V1 SSE API emulation requires the `emulate_legacy_sse_apis` setting to be `["V1"]`:
+
 ```
 [sse_server]
-(...)
+enable_server = true
 emulate_legacy_sse_apis = ["V1"]
-(...)
 ```
 
-This will expose three additional sse endpoints:
-* `/events/sigs`
-* `/events/deploys`
-* `/events/main`
+This setting will expose three legacy SSE endpoints with the following events streamed on each endpoint:
+* `/events/sigs` - Finality Signature events
+* `/events/deploys` - DeployAccepted events
+* `/events/main` - All other legacy events, including BlockAdded, DeployProcessed, DeployExpired, Fault, Step, and Shutdown events
 
-Those endpoints will emit events in the same format as the V1 SSE API of the casper node. There are limitations to what Casper Sidecar can and will do, here is a list of assumptions:
+<!-- TODO -> fill this in the next PR when mapping is implemented 
+Those endpoints will emit events in the same format as the V1 SSE API of the Casper node. There are limitations to what the Casper Sidecar can and will do. Here is a list of assumptions:
+-->
 
-TODO -> fill this in the next PR when mapping is implemented
+#### Event stream configuration
+
+To configure the Sidecar's event stream server, specify the following settings:
+
+```
+[sse_server.event_stream_server]
+port = 19999
+max_concurrent_subscribers = 100
+event_stream_buffer_length = 5000
+```
+
+* `event_stream_server.port` - The port under which the Sidecar's SSE server publishes events.
+* `event_stream_server.max_concurrent_subscribers` - The maximum number of subscribers that can monitor the Sidecar's event stream.
+* `event_stream_server.event_stream_buffer_length` - The number of events that the stream will hold in its buffer for reference when a subscriber reconnects.
+
+### REST server configuration
+
+The following section determines outbound connection criteria for the Sidecar's REST server.
+
+```
+[rest_api_server]
+enable_server = true
+port = 18888
+max_concurrent_requests = 50
+max_requests_per_second = 50
+request_timeout_in_seconds = 10
+```
+
+* `enable_server` - If set to true, the RPC API server will be enabled.
+* `port` - The port for accessing the Sidecar's REST server. `18888` is the default, but operators are free to choose their own port as needed.
+* `max_concurrent_requests` - The maximum total number of simultaneous requests that can be made to the REST server.
+* `max_requests_per_second` - The maximum total number of requests that can be made per second.
+* `request_timeout_in_seconds` - The total time before a request times out.
 
 ### Storage
 
-This directory stores the SSE cache and an SQLite database if the Sidecar is configured to use SQLite.
+This directory stores the SSE cache and an SQLite database if the Sidecar was configured to use SQLite.
 
 ```
 [storage]
 storage_path = "./target/storage"
 ```
 
-### Database Connectivity
+### Database connectivity
 
-The Sidecar can connect to different types of databases. The current options are `SQLite` or `PostgreSQL`. The following sections show how to configure the database connection for one of these DBs. Note that the Sidecar can only connect to one DB at a time.
+The Sidecar can connect to different types of databases. The current options are `SQLite` or `PostgreSQL`. The following sections show how to configure the database connection. Note that the Sidecar can only connect to one database at a time.
 
-#### SQLite Database
+#### SQLite database
 
 This section includes configurations for the SQLite database.
 
@@ -311,7 +368,6 @@ This section includes configurations for the SQLite database.
 [storage.sqlite_config]
 file_name = "sqlite_database.db3"
 max_connections_in_pool = 100
-# https://www.sqlite.org/compile.html#default_wal_autocheckpoint
 wal_autocheckpointing_interval = 1000
 ```
 
@@ -319,7 +375,7 @@ wal_autocheckpointing_interval = 1000
 * `storage.sqlite_config.max_connections_in_pool` - The maximum number of connections to the database (should generally be left as is).
 * `storage.sqlite_config.wal_autocheckpointing_interval` - This controls how often the system commits pages to the database. The value determines the maximum number of pages before forcing a commit. More information can be found [here](https://www.sqlite.org/compile.html#default_wal_autocheckpoint).
 
-#### PostgreSQL Database
+#### PostgreSQL database
 
 The properties listed below are elements of the PostgreSQL database connection that can be configured for the Sidecar.
 
@@ -357,9 +413,7 @@ SIDECAR_POSTGRES_MAX_CONNECTIONS="max connections"
 SIDECAR_POSTGRES_PORT="port"
 ```
 
-However, DB connectivity can also be configured using the Sidecar configuration file.
-
-If the DB environment variables and the Sidecar's configuration file have the same variable set, the DB environment variables will take precedence.
+However, DB connectivity can also be configured using the Sidecar configuration file. If the DB environment variables and the Sidecar's configuration file have the same variable set, the DB environment variables will take precedence.
 
 It is possible to completely omit the PostgreSQL configuration from the Sidecar's configuration file. In this case, the Sidecar will attempt to connect to the PostgreSQL using the database environment variables or use some default values for non-critical variables.
 
@@ -372,40 +426,7 @@ database_username = "postgres"
 max_connections_in_pool = 30
 ```
 
-#### Rest & Event Stream Criteria
-
-This information determines outbound connection criteria for the Sidecar's `rest_server`.
-
-```
-[rest_api_server]
-enable_server = true
-port = 18888
-max_concurrent_requests = 50
-max_requests_per_second = 50
-request_timeout_in_seconds = 10
-```
-* `enable_server` - If set to true, the RPC API server will be enabled.
-* `port` - The port for accessing the sidecar's `rest_server`. `18888` is the default, but operators are free to choose their own port as needed.
-* `max_concurrent_requests` - The maximum total number of simultaneous requests that can be made to the REST server.
-* `max_requests_per_second` - The maximum total number of requests that can be made per second.
-* `request_timeout_in_seconds` - The total time before a request times out.
-
-```
-[sse_server.event_stream_server]
-port = 19999
-max_concurrent_subscribers = 100
-event_stream_buffer_length = 5000
-```
-
-The `sse_server.event_stream_server` section specifies a port for the Sidecar's event stream.
-
-Additionally, there are the following two options:
-
-* `event_stream_server.port` - Port under which the SSE server is published.
-* `event_stream_server.max_concurrent_subscribers` - The maximum number of subscribers that can monitor the Sidecar's event stream.
-* `event_stream_server.event_stream_buffer_length` - The number of events that the stream will hold in its buffer for reference when a subscriber reconnects.
-
-### Admin Server
+### Admin server configuration
 
 This optional section configures the Sidecar's administrative server. If this section is not specified, the Sidecar will not start an admin server.
 
@@ -432,25 +453,9 @@ Once the Sidecar is running, access the Swagger documentation at `http://localho
 
 An OpenAPI schema is available at `http://localhost:18888/api-doc.json/`. You need to replace `localhost` with the IP address of the machine running the Sidecar application if you are running the Sidecar remotely.
 
-## Unit Testing the Sidecar
-
-You can run the unit and integration tests included in this repository with the following command:
-
-```
-cargo test
-```
-
-You can also run the performance tests using the following command:
-
-```
-cargo test -- --include-ignored
-```
-
-The [EXAMPLE_NCTL_CONFIG.toml](./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml) file contains the configurations used for these tests.
-
 ## Running the Sidecar
 
-After creating the configuration file, run the Sidecar using Cargo and point to the configuration file using the `--path-to-config` option, as shown below. The command needs to run with `root` privileges.
+After creating the configuration file, run the Sidecar using `cargo` and point to the configuration file using the `--path-to-config` option, as shown below. The command needs to run with `root` privileges.
 
 ```shell
 sudo cargo run -- --path-to-config ./resources/example_configs/EXAMPLE_NODE_CONFIG.toml
@@ -458,7 +463,7 @@ sudo cargo run -- --path-to-config ./resources/example_configs/EXAMPLE_NODE_CONF
 
 The Sidecar application leverages tracing, which can be controlled by setting the `RUST_LOG` environment variable.
 
-The following command will run the sidecar application with the `INFO` log level.
+The following command will run the Sidecar application with the `INFO` log level.
 
 ```
 RUST_LOG=info cargo run -p casper-sidecar -- --path-to-config ./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
@@ -474,11 +479,27 @@ The log levels, listed in order of increasing verbosity, are:
 
 Further details about log levels can be found [here](https://docs.rs/env_logger/0.9.1/env_logger/#enabling-logging).
 
-## Testing the Sidecar using NCTL
+## Testing the Sidecar
+
+You can run the unit and integration tests included in this repository with the following command:
+
+```
+cargo test
+```
+
+You can also run the performance tests using this command:
+
+```
+cargo test -- --include-ignored
+```
+
+The [EXAMPLE_NCTL_CONFIG.toml](./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml) file contains the configurations used for these tests.
+
+### Testing the Sidecar using NCTL
 
 The Sidecar application can be tested against live Casper nodes or a local [NCTL network](https://docs.casperlabs.io/dapp-dev-guide/building-dapps/setup-nctl/).
 
-The configuration shown within this README will direct the Sidecar application to a locally hosted NCTL network if one is running. The Sidecar should function the same way it would with a live node, displaying events as they occur in the local NCTL network.
+The configuration shown [here](./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml) will direct the Sidecar application to a locally hosted NCTL network if one is running. The Sidecar should function the same way it would while connected to a live node, displaying events as they occur in the local NCTL network.
 
 ## Troubleshooting Tips
 
@@ -509,7 +530,7 @@ curl http://SIDECAR_URL:SIDECAR_ADMIN_PORT/metrics
 **Sample output**:
 
 ```
-# HELP node_statuses Current status of node to which sidecar is connected. Numbers mean: 0 - preparing; 1 - connecting; 2 - connected; 3 - reconnecting; -1 - connections_exhausted -> used up all connection attempts ; -2 - incompatible -> node is in an incompatible version
+# HELP node_statuses Current status of node to which the Sidecar is connected. Numbers mean: 0 - preparing; 1 - connecting; 2 - connected; 3 - reconnecting; -1 - connections_exhausted -> used up all connection attempts ; -2 - incompatible -> node is in an incompatible version
 # TYPE node_statuses gauge
 node_statuses{node="35.180.42.211:9999"} 2
 node_statuses{node="69.197.42.27:9999"} 2

--- a/README.md
+++ b/README.md
@@ -55,18 +55,21 @@ The Casper Sidecar provides the following functionalities:
 The Sidecar has the following components and external dependencies:
 
 ```mermaid
+---
+title: The Casper Sidecar Components
+---
    graph LR;
-   subgraph CASPER-SIDECAR
+   subgraph CASPER_SIDECAR
       SSE_SERVER["SSE server"]
-      RPC_API_SERVER["RPC API server (json)"]
+      RPC_API_SERVER["RPC API server (JSON)"]
       REST_API["Rest API server"]
       ADMIN_API["Admin API server"]
    end
-   CONFIG{{"Config file (toml)"}}
-   CONFIG --> CASPER-SIDECAR
+   CONFIG{{"Config file (TOML)"}}
+   CONFIG --> CASPER_SIDECAR
    STORAGE[(Storage)]
-   NODE_SSE(("Casper Node SSE port"))
-   NODE_BINARY(("Casper Node binary port"))
+   NODE_SSE(("Casper node SSE port"))
+   NODE_BINARY(("Casper node binary port"))
    RPC_API_SERVER --> NODE_BINARY
    SSE_SERVER --> NODE_SSE
    SSE_SERVER --> STORAGE
@@ -82,21 +85,21 @@ The SSE Server has these components:
    CLIENT{Client}
    CLIENT --> SSE_SERVER_API
    STORAGE[("Storage")]
-   CONFIG{{"Config file (toml)"}}
+   CONFIG{{"Config file (TOML)"}}
    MAIN --1.reads--> CONFIG
    NODE_SSE{Node SSE port}
    SSE_LISTENER --2--> STORAGE
    NODE_SSE --1--> SSE_LISTENER
-   subgraph "Casper Sidecar"
+   subgraph CASPER_SIDECAR
      MAIN[main.rs]
-     MAIN --2.spawns---> SSE-SERVER
-     subgraph SSE-SERVER
+     MAIN --2.spawns---> SSE_SERVER
+     subgraph SSE_SERVER
         SSE_SERVER_API["SSE API"]
         RING_BUFFER["Events buffer"]
         SSE_SERVER_API --> RING_BUFFER
         SSE_LISTENER --3--> RING_BUFFER
-        subgraph "For connection in connections"
-          SSE_LISTENER["SSE Listener"]   
+        subgraph "connection"
+          SSE_LISTENER["SSE listener"]   
         end
      end
    end
@@ -126,9 +129,9 @@ The Sidecar offers an optional REST API that allows clients to query the events 
    CLIENT --> REST_API
    STORAGE[("Storage")]
    REST_API --> STORAGE
-   CONFIG{{"Config file (toml)"}}
+   CONFIG{{"Config file (TOML)"}}
    MAIN --1.reads--> CONFIG
-   subgraph "Casper Sidecar"
+   subgraph CASPER_SIDECAR
       MAIN[main.rs]
       MAIN --2.spawns--> REST_API
       REST_API["REST API"]
@@ -145,7 +148,7 @@ The Sidecar offers an administrative API to allow an operator to check its curre
    CLIENT --> ADMIN_API
    CONFIG{{Config file}}
    MAIN --1.reads--> CONFIG
-   subgraph "Casper Sidecar"
+   subgraph CASPER_SIDECAR
       MAIN[main.rs]
       MAIN --2.spawns--> ADMIN_API
       ADMIN_API["ADMIN API"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![LOGO](https://raw.githubusercontent.com/casper-network/casper-node/master/images/casper-association-logo-primary.svg)](https://casper.network/)
+
+[![License](https://img.shields.io/badge/license-Apache-blue)](https://github.com/CasperLabs/casper-node/blob/master/LICENSE)
+
 # The Casper Sidecar
 
 - [Summary of Purpose](#summary-of-purpose)
@@ -618,3 +622,7 @@ The easiest way to inspect the Sidecar’s REST API is with [Swagger](#swagger-d
 The Sidecar can be configured to limit concurrent requests (`max_concurrent_requests`) and requests per second (`max_requests_per_second`) for the REST and admin servers.
 
 However, remember that those are application-level guards, meaning that the operating system already accepted the connection, which used up the operating system's resources. Limiting potential DDoS attacks requires consideration before the requests are directed to the Sidecar application.
+
+## License
+
+Licensed under the [Apache License Version 2.0](https://github.com/casper-network/casper-node/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
    - [The REST API server](#the-rest-api-server)
 	- [The Admin API server](#the-admin-api-server)
 	- [The RPC API server](#the-rpc-api-server)
-- [Running and Testing the Sidecar](#running-and-testing-the-sidecar)
-	- [Prerequisites](#prerequisites)
-	- [Configuration](#configuration)
+- [Configuring the Sidecar](#configuring-the-sidecar)
 	- [RPC server setup](#rpc-server-setup)
 	- [SSE server setup](#sse-server-setup)
 		- [Configuring SSE node connections](#configuring-sse-node-connections)
@@ -20,11 +18,12 @@
 		- [SQLite database](#sqlite-database)
 		- [PostgreSQL database](#postgresql-database)
 	- [Admin server setup](#admin-server-setup)
+- [Running and Testing the Sidecar](#running-and-testing-the-sidecar)
+	- [Prerequisites](#prerequisites)
+   - [Running the Sidecar](#running-the-sidecar)
+   - [Testing the Sidecar](#testing-the-sidecar)
 - [Swagger Documentation](#swagger-documentation)
 - [OpenAPI Specification](#openapi-specification)
-- [Running the Sidecar](#running-the-sidecar)
-- [Testing the Sidecar](#testing-the-sidecar)
-	- [Testing the Sidecar using NCTL](#testing-the-sidecar-using-nctl)
 - [Troubleshooting Tips](#troubleshooting-tips)
 	- [Checking liveness](#checking-liveness)
 	- [Checking the node connection](#checking-the-node-connection)
@@ -167,19 +166,8 @@ The Sidecar also offers an RPC JSON API server that can be enabled and configure
    end
 ```
 
-## Running and Testing the Sidecar
+## Configuring the Sidecar
 
-### Prerequisites
-
-To compile, test, and run the Sidecar, install the following software first:
-
-* CMake 3.1.4 or greater
-* [Rust](https://www.rust-lang.org/tools/install)
-* pkg-config
-* gcc
-* g++
-
-### Configuration
 
 The Sidecar service must be configured using a `.toml` file specified at runtime.
 
@@ -381,7 +369,7 @@ request_timeout_in_seconds = 10
 * `max_requests_per_second` - The maximum total number of requests that can be made per second.
 * `request_timeout_in_seconds` - The total time before a request times out.
 
-### Dtorage setup
+### Storage setup
 
 This directory stores the SSE cache and an SQLite database if the Sidecar was configured to use SQLite.
 
@@ -479,15 +467,19 @@ max_requests_per_second = 1
 
 Access the admin server at `http://localhost:18887/metrics/`.
 
-## Swagger Documentation
+## Running and Testing the Sidecar
 
-Once the Sidecar is running, access the Swagger documentation at `http://localhost:18888/swagger-ui/`. You need to replace `localhost` with the IP address of the machine running the Sidecar application if you are running the Sidecar remotely. The Swagger documentation will allow you to test the REST API.
+### Prerequisites
 
-## OpenAPI Specification
+To compile, test, and run the Sidecar, install the following software first:
 
-An OpenAPI schema is available at `http://localhost:18888/api-doc.json/`. You need to replace `localhost` with the IP address of the machine running the Sidecar application if you are running the Sidecar remotely.
+* CMake 3.1.4 or greater
+* [Rust](https://www.rust-lang.org/tools/install)
+* pkg-config
+* gcc
+* g++
 
-## Running the Sidecar
+### Running the Sidecar
 
 After creating the configuration file, run the Sidecar using `cargo` and point to the configuration file using the `--path-to-config` option, as shown below. The command needs to run with `root` privileges.
 
@@ -513,7 +505,7 @@ The log levels, listed in order of increasing verbosity, are:
 
 Further details about log levels can be found [here](https://docs.rs/env_logger/0.9.1/env_logger/#enabling-logging).
 
-## Testing the Sidecar
+### Testing the Sidecar
 
 You can run the unit and integration tests included in this repository with the following command:
 
@@ -529,11 +521,19 @@ cargo test -- --include-ignored
 
 The [EXAMPLE_NCTL_CONFIG.toml](./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml) file contains the configurations used for these tests.
 
-### Testing the Sidecar using NCTL
+#### Testing the Sidecar using NCTL
 
 The Sidecar application can be tested against live Casper nodes or a local [NCTL network](https://docs.casperlabs.io/dapp-dev-guide/building-dapps/setup-nctl/).
 
 The configuration shown [here](./resources/example_configs/EXAMPLE_NCTL_CONFIG.toml) will direct the Sidecar application to a locally hosted NCTL network if one is running. The Sidecar should function the same way it would while connected to a live node, displaying events as they occur in the local NCTL network.
+
+## Swagger Documentation
+
+Once the Sidecar is running, access the Swagger documentation at `http://localhost:18888/swagger-ui/`. You need to replace `localhost` with the IP address of the machine running the Sidecar application if you are running the Sidecar remotely. The Swagger documentation will allow you to test the REST API.
+
+## OpenAPI Specification
+
+An OpenAPI schema is available at `http://localhost:18888/api-doc.json/`. You need to replace `localhost` with the IP address of the machine running the Sidecar application if you are running the Sidecar remotely.
 
 ## Troubleshooting Tips
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@
 
 ## Summary of Purpose
 
-The Casper Sidecar application runs in tandem with the node process, and its primary purpose is to:
+The Casper Sidecar is an application running in tandem with the node process. It allows subscribers to monitor a node's event stream, query stored events, and query the node's JSON RPC API, thus receiving faster responses and reducing the load placed on the node. Its primary purpose is to:
+
 * Offload the node from broadcasting SSE events to multiple clients.
 * Provide client features that aren't part of the nodes' functionality, nor should they be.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The SSE Listener processes events in this order:
 2. Store the event.
 3. Publish the event to the SSE API.
 
-Casper nodes offer an event stream API that returns server-sent events (SSEs) with JSON-encoded data. The Sidecar reads the event stream of all connected nodes, acting as a passthrough and replicating the SSE interface of the connected nodes. The Sidecar can:
+Casper nodes offer an event stream API that returns server-sent events (SSEs) with JSON-encoded data. The Sidecar reads the event stream of all connected nodes, acting as a passthrough and replicating the SSE interface of the connected nodes.
 
 The Sidecar can:
 * Republish the current events from the node to clients listening to Sidecar's SSE API.
@@ -122,7 +122,7 @@ Enabling and configuring the SSE Server of the Sidecar is optional.
 
 ### The REST API server
 
-The Sidecar offers an optional REST API that allows clients to query the events stored in external storage. Node operators can discover the specific endpoints of the REST API using [OpenAPI] (#openapi-specification) and [Swagger] (#swagger-documentation). The [usage instructions](USAGE.md) provide more details.
+The Sidecar offers an optional REST API that allows clients to query the events stored in external storage. You can discover the specific endpoints of the REST API using [OpenAPI](#openapi-specification) and [Swagger](#swagger-documentation). The [usage instructions](USAGE.md) provide more details.
 
 ```mermaid
    graph LR;

--- a/USAGE.md
+++ b/USAGE.md
@@ -26,7 +26,7 @@ It is possible to monitor the Sidecar event stream using *cURL*, depending on ho
 
 The Sidecar can connect to Casper nodes with versions greater or equal to `2.0.0`.
 
-```json
+```sh
 curl -s http://<HOST:PORT>/events
 ```
 
@@ -35,15 +35,15 @@ curl -s http://<HOST:PORT>/events
 
 Given this [example configuration](./resources/example_configs/EXAMPLE_NODE_CONFIG.toml), here are the commands for each endpoint:
 
-    ```json
-    curl -sN http://127.0.0.1:19999/events
-    ```
+```sh
+curl -sN http://127.0.0.1:19999/events
+```
 
 Also, the Sidecar exposes an endpoint for Sidecar-generated events:
 
-    ```json
-    curl -sN http://127.0.0.1:19999/events/sidecar
-    ```
+```sh
+curl -sN http://127.0.0.1:19999/events/sidecar
+```
 
 ### Node events versioning
 
@@ -53,7 +53,7 @@ If the node goes offline, the `ApiVersion` may differ when it restarts (i.e., in
 
 Here is an example of what the API version would look like while listening on the Sidecar’s event stream. The colons represent "keep-alive" messages.
 
-```
+```sh
 curl -sN http://127.0.0.1:19999/events
 
 data:{"ApiVersion":"2.0.0"}
@@ -74,7 +74,7 @@ id:21821471
 
 When a client connects to the `events/sidecar` endpoint, it will receive a message containing the version of the Sidecar software. Release version `1.1.0` would look like this:
 
-```
+```sh
 curl -sN http://127.0.0.1:19999/events/sidecar
 
 data:{"SidecarVersion":"1.1.0"}
@@ -82,7 +82,6 @@ data:{"SidecarVersion":"1.1.0"}
 :
 
 :
-
 ```
 
 Note that the SidecarVersion differs from the APIVersion emitted by the node event streams. You will also see the keep-alive messages as colons, ensuring the connection is active.
@@ -95,7 +94,7 @@ The Sidecar does not expose Shutdown events via its REST API.
 
 Here is an example of how the stream might look like if the node went offline for an upgrade and came back online after a Shutdown event with a new `ApiVersion`:
 
-```
+```sh
 curl -sN http://127.0.0.1:19999/events
 
 data:{"ApiVersion":"2.0.0"}
@@ -122,7 +121,6 @@ id:3
 :
 
 :
-
 ```
 
 Note that the Sidecar can emit another type of shutdown event on the `events/sidecar` endpoint, as described below.
@@ -133,7 +131,7 @@ If the Sidecar attempts to connect to a node that does not come back online with
 
 The message structure of the Sidecar shutdown event is the same as the [node shutdown event](#the-node-shutdown-event). The Sidecar event stream would look like this:
 
-```
+```sh
 curl -sN http://127.0.0.1:19999/events/sidecar
 
 data:{"SidecarVersion":"1.1.0"}
@@ -160,7 +158,7 @@ The path URL is `<HOST:PORT>/block`.
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/block
 ```
 
@@ -182,7 +180,7 @@ The path URL is `<HOST:PORT>/block/<block-hash>`. Enter a valid block hash.
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/block/bd2e0c36150a74f50d9884e38a0955f8b1cba94821b9828c5f54d8929d6151bc
 ```
 
@@ -203,7 +201,7 @@ The path URL is `<HOST:PORT>/block/<block-height>`. Enter a valid number represe
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/block/336460
 ```
 
@@ -226,7 +224,7 @@ The output differs depending on the transaction's status, which changes over tim
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888//transaction/version1/3141e85f8075c3a75c2a1abcc79810c07d103ff97c03200ab0d0baf91995fe4a
 ```
 
@@ -236,7 +234,8 @@ The sample output below is for a transaction that was accepted but has yet to be
 <summary><b>Transaction accepted but not processed yet</b></summary>
 
 ```json
-{"transaction_hash": "3141e85f8075c3a75c2a1abcc79810c07d103ff97c03200ab0d0baf91995fe4a","transaction_accepted": {"header": {"api_version": "2.0.0","network_name": "casper-net-1"},"payload": {"transaction": {"Version1": {"hash": "3141e85f8075c3a75c2a1abcc79810c07d103ff97c03200ab0d0baf91995fe4a","header": {"chain_name": "casper-net-1","timestamp": "2024-03-20T13:31:59.772Z","ttl": "30m","body_hash": "40c7476a175fb97656ec6da1ace2f1900a9d353f1637943a30edd5385494b345","pricing_mode": {"Fixed": {"gas_price_tolerance": 1000}},"initiator_addr": {"PublicKey": "01d848e225db95e34328ca1c64d73ecda50f5070fd6b21037453e532d085a81973"}},"body": {"args": [],"target": {"Session": {"kind": "Standard","module_bytes":"<REDACTED>","runtime": "VmCasperV1"}},"entry_point": {"Custom": "test"},"scheduling": "Standard"},"approvals": [{"signer": "01d848e225db95e34328ca1c64d73ecda50f5070fd6b21037453e532d085a81973","signature": "0154fd295f5d4d62544f63d70470de28b2bf2cddecac2a237b6a2a78d25ee14b21ea2861d711a51f57b3f9f74e247a8d26861eceead6569f233949864a9d5fa100"}]}}}},"transaction_processed": ,"transaction_expired": false}```
+{"transaction_hash": "3141e85f8075c3a75c2a1abcc79810c07d103ff97c03200ab0d0baf91995fe4a","transaction_accepted": {"header": {"api_version": "2.0.0","network_name": "casper-net-1"},"payload": {"transaction": {"Version1": {"hash": "3141e85f8075c3a75c2a1abcc79810c07d103ff97c03200ab0d0baf91995fe4a","header": {"chain_name": "casper-net-1","timestamp": "2024-03-20T13:31:59.772Z","ttl": "30m","body_hash": "40c7476a175fb97656ec6da1ace2f1900a9d353f1637943a30edd5385494b345","pricing_mode": {"Fixed": {"gas_price_tolerance": 1000}},"initiator_addr": {"PublicKey": "01d848e225db95e34328ca1c64d73ecda50f5070fd6b21037453e532d085a81973"}},"body": {"args": [],"target": {"Session": {"kind": "Standard","module_bytes":"<REDACTED>","runtime": "VmCasperV1"}},"entry_point": {"Custom": "test"},"scheduling": "Standard"},"approvals": [{"signer": "01d848e225db95e34328ca1c64d73ecda50f5070fd6b21037453e532d085a81973","signature": "0154fd295f5d4d62544f63d70470de28b2bf2cddecac2a237b6a2a78d25ee14b21ea2861d711a51f57b3f9f74e247a8d26861eceead6569f233949864a9d5fa100"}]}}}},"transaction_processed": ,"transaction_expired": false}
+```
 </details>
 <br></br>
 
@@ -260,7 +259,7 @@ The path URL is `<HOST:PORT>/transaction/accepted/<transaction-type>/<transactio
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/transaction/accepted/version1/8204af872d7d19ef8da947bce67c7a55449bc4e2aa12d2756e9ec7472b4854f7
 ```
 
@@ -282,7 +281,7 @@ The path URL is `<HOST:PORT>/transaction/expired/<transaction-type>/<transaction
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/transaction/expired/version1/3dcf9cb73977a1163129cb0801163323bea2a780815bc9dc46696a43c00e658c
 ```
 
@@ -301,7 +300,7 @@ The path URL is `<HOST:PORT>/transaction/expired/version1/<transaction-hash>`. E
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/transaction/processed/version1/8204af872d7d19ef8da947bce67c7a55449bc4e2aa12d2756e9ec7472b4854f7
 ```
 
@@ -322,7 +321,7 @@ The path URL is `<HOST:PORT>/faults/<public-key>`. Enter a valid hexadecimal rep
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/faults/01a601840126a0363a6048bfcbb0492ab5a313a1a19dc4c695650d8f3b51302703
 ```
 
@@ -333,7 +332,7 @@ The path URL is: `<HOST:PORT>/faults/<era-ID>`. Enter an era identifier.
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/faults/2304
 ```
 
@@ -345,7 +344,7 @@ The path URL is: `<HOST:PORT>/signatures/<block-hash>`. Enter a valid block hash
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/signatures/85aa2a939bc3a4afc6d953c965bab333bb5e53185b96bb07b52c295164046da2
 ```
 
@@ -357,7 +356,7 @@ The path URL is: `<HOST:PORT>/step/<era-ID>`. Enter a valid era identifier.
 
 Example:
 
-```json
+```sh
 curl -s http://127.0.0.1:18888/step/7268
 ```
 
@@ -367,7 +366,7 @@ If no filter URL was specified after the root address (HOST:PORT), an error mess
 
 Example:
 
-```json
+```sh
 curl http://127.0.0.1:18888
 {"code":400,"message":"Invalid request path provided"}
 ```
@@ -378,7 +377,7 @@ If an invalid filter was specified, an error message will be returned.
 
 Example:
 
-```json
+```sh
 curl http://127.0.0.1:18888/other
 {"code":400,"message":"Invalid request path provided"}
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -131,7 +131,7 @@ Note that the Sidecar can emit another type of shutdown event on the `events/sid
 
 If the Sidecar attempts to connect to a node that does not come back online within the maximum number of reconnection attempts, the Sidecar will start a controlled shutdown process. It will emit a Sidecar-specific Shutdown event on the [events/sidecar](#the-sidecar-shutdown-event) endpoint, designated for events originating solely from the Sidecar service. The other event streams do not get this message because they only emit messages from the node.
 
-The message structure of the Sidecar shutdown event is the same as the [node shutdown event](#the-node-shutdown-event). The sidecar event stream would look like this:
+The message structure of the Sidecar shutdown event is the same as the [node shutdown event](#the-node-shutdown-event). The Sidecar event stream would look like this:
 
 ```
 curl -sN http://127.0.0.1:19999/events/sidecar

--- a/event_sidecar/src/utils.rs
+++ b/event_sidecar/src/utils.rs
@@ -263,14 +263,14 @@ pub mod tests {
         config: TestingConfig,
     ) -> tokio::task::JoinHandle<Result<ExitCode, Error>> {
         tokio::spawn(async move { unpack_test_config_and_run(config, true).await })
-        // starting event sidecar
+        // starting the sidecar
     }
 
     pub async fn start_sidecar(
         config: TestingConfig,
     ) -> tokio::task::JoinHandle<Result<ExitCode, Error>> {
         tokio::spawn(async move { unpack_test_config_and_run(config, false).await })
-        // starting event sidecar
+        // starting the sidecar
     }
 
     pub fn build_test_config() -> (TestingConfig, TempDir, u16, u16, u16) {

--- a/json_rpc/README.md
+++ b/json_rpc/README.md
@@ -1,4 +1,4 @@
-# `casper-json-rpc`
+# The `casper-json-rpc` Library
 
 [![LOGO](https://raw.githubusercontent.com/casper-network/casper-node/master/images/casper-association-logo-primary.svg)](https://casper.network/)
 
@@ -7,16 +7,15 @@
 [![Documentation](https://docs.rs/casper-node/badge.svg)](https://docs.rs/casper-json-rpc)
 [![License](https://img.shields.io/badge/license-Apache-blue)](https://github.com/casper-network/casper-node/blob/master/LICENSE)
 
-A library suitable for use as the framework for a JSON-RPC server.
+The `casper-json-rpc` library described here can be used as the framework for a JSON-RPC server.
 
 # Usage
 
-Normally usage will involve two steps:
-  * construct a set of request handlers using a
-    [`RequestHandlersBuilder`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/struct.RequestHandlersBuilder.html)
-  * call [`casper_json_rpc::route`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/fn.route.html) to construct a
-    boxed warp filter ready to be passed to [`warp::service`](https://docs.rs/warp/latest/warp/fn.service.html) for
-    example
+Typical usage of this library involves two steps:
+
+* Construct a set of request handlers using a
+[`RequestHandlersBuilder`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/struct.RequestHandlersBuilder.html).
+* Call [`casper_json_rpc::route`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/fn.route.html) to construct a boxed warp filter ready to be passed to [`warp::service`](https://docs.rs/warp/latest/warp/fn.service.html).
 
 # Example
 
@@ -61,15 +60,15 @@ async fn main() {
 }
 ```
 
-If this receives a request such as
+The following is a sample request:
 
-```
+```sh
 curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"id","method":"get"}' http://127.0.0.1:3030/rpc
 ```
 
-then the server will respond with
+Here is a sample response:
 
-```json
+```sh
 {"jsonrpc":"2.0","id":"id","result":"got it"}
 ```
 
@@ -77,13 +76,12 @@ then the server will respond with
 
 To return a JSON-RPC response indicating an error, use
 [`Error::new`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/struct.Error.html#method.new).  Most error
-conditions which require returning a reserved error are already handled in the provided warp filters.  The only
+conditions that require returning a reserved error are already handled in the provided warp filters.  The only
 exception is
-[`ReservedErrorCode::InvalidParams`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/enum.ReservedErrorCode.html#variant.InvalidParams)
-which should be returned by any RPC handler which deems the provided `params: Option<Params>` to be invalid for any
+[`ReservedErrorCode::InvalidParams`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/enum.ReservedErrorCode.html#variant.InvalidParams), which should be returned by any RPC handler that deems the provided `params: Option<Params>` to be invalid for any
 reason.
 
-Generally a set of custom error codes should be provided.  These should all implement
+Generally, a set of custom error codes should be provided.  These should all implement
 [`ErrorCodeT`](https://docs.rs/casper-json-rpc/latest/casper_json_rpc/trait.ErrorCodeT.html).
 
 ## Example custom error code

--- a/resources/ETC_README.md
+++ b/resources/ETC_README.md
@@ -1,226 +1,32 @@
-# Casper Event Sidecar README for Node Operators
+# Casper Sidecar README for Node Operators
 
-## Summary of Purpose
+This page contains specific instructions for node operators. Before proceeding, familiarize yourself with the main [README](../README.md) file, which covers the following:
+ - [Summary of purpose](../README.md#summary-of-purpose)
+ - [System components and architecture](../README.md#system-components-and-architecture)
+ - [Configuration options](../README.md#configuring-the-sidecar)
+ - [Running and testing the Sidecar](../README.md#running-and-testing-the-sidecar)
+ - [Troubleshooting tips](../README.md#troubleshooting-tips)
 
-The Casper Event Sidecar is an application that runs in tandem with the node process. This reduces the load on the node process by allowing subscribers to monitor the event stream through the Sidecar, while the node focuses entirely on the blockchain. Users needing access to the JSON-RPC will still need to query the node directly.
-
-While the primary use case for the Sidecar application is running alongside the node on the same machine, it can be run remotely if necessary.
-
-### System Components & Architecture
-
-Casper Nodes offer a Node Event Stream API returning Server-Sent Events (SSEs) that hold JSON-encoded data. The SSE Sidecar uses this API to achieve the following goals:
-
-* Build a sidecar middleware service that reads the Event Stream of all connected nodes, acting as a passthrough and replicating the SSE interface of the connected nodes and their filters (i.e., `/main`, `/deploys`, and `/sigs` with support for the use of the `?start_from=` query to allow clients to get previously sent events from the Sidecar's buffer).
-
-* Provide a new RESTful endpoint that is discoverable to node operators.
-
-The SSE Sidecar uses one ring buffer for outbound events, providing some robustness against unintended subscriber disconnects. If a disconnected subscriber re-subscribes before the buffer moves past their last received event, there will be no gap in the event history if they use the `start_from` URL query.
-
-
-## Configuration
+## Sidecar Configuration on the Node
 
 The file `/etc/casper-sidecar/config.toml` holds a default configuration. This should work if installed on a Casper node.
 
 If you install the Sidecar on an external server, you must update the `ip-address` values under `node_connections` appropriately.
 
-### Node Connections
+For more information, including how to setup the SSE, RPC, REST, and Admin servers, read the [configuration options](../README.md#configuring-the-sidecar) in the main README.
 
-The Sidecar can connect to Casper nodes with versions greater or equal to `2.0.0`.
+## Storage on the Node
 
-The `node_connections` option configures the node (or multiple nodes) to which the Sidecar will connect and the parameters under which it will operate with that node.
-
-```
-[[sse_server.connections]]
-ip_address = "127.0.0.1"
-sse_port = 9999
-rest_port = 8888
-max_attempts = 10
-delay_between_retries_in_seconds = 5
-allow_partial_connection = false
-enable_logging = true
-connection_timeout_in_seconds = 3
-no_message_timeout_in_seconds = 60
-sleep_between_keep_alive_checks_in_seconds = 30
-```
-
-* `ip_address` - The IP address of the node to monitor.
-* `sse_port` - The node's event stream (SSE) port. This [example configuration](../resources/example_configs/EXAMPLE_NODE_CONFIG.toml) uses port `9999`.
-* `rest_port` - The node's REST endpoint for status and metrics. This [example configuration](../resources/example_configs/EXAMPLE_NODE_CONFIG.toml) uses port `8888`.
-* `max_attempts` - The maximum number of attempts the Sidecar will make to connect to the node. If set to `0`, the Sidecar will not attempt to connect.
-* `delay_between_retries_in_seconds` - The delay between attempts to connect to the node.
-* `allow_partial_connection` - Determining whether the sidecar will allow a partial connection to this node.
-* `enable_logging` - This enables logging of events from the node in question.
-* `connection_timeout_in_seconds` - Number of seconds before the connection request times out. Parameter is optional, defaults to 5
-* `no_message_timeout_in_seconds` - Number of seconds after which the connection will be restarted if no bytes were received. Parameter is optional, defaults to 120
-* `sleep_between_keep_alive_checks_in_seconds` - Optional parameter specifying the time intervals (in seconds) for checking if the connection is still alive. Defaults to 60
-
-Connecting to multiple nodes requires multiple `[[sse_server.connections]]` sections:
-
-```
-[[sse_server.connections]]
-ip_address = "127.0.0.1"
-sse_port = 9999
-rest_port = 8888
-max_attempts = 10
-delay_between_retries_in_seconds = 5
-allow_partial_connection = false
-enable_logging = true
-
-[[sse_server.connections]]
-ip_address = "18.154.79.193"
-sse_port = 1234
-rest_port = 3456
-max_attempts = 10
-delay_between_retries_in_seconds = 5
-allow_partial_connection = false
-enable_logging = true
-```
-
-### Storage
-
-This directory stores the SSE cache and an SQLite database if the Sidecar is configured to use SQLite.
+This directory stores the SSE cache and a database if the Sidecar was configured to use one.
 
 ```
 [storage]
 storage_path = "/var/lib/casper-sidecar"
 ```
 
-### Database Connectivity
+The DB setup is described [here](../README#database-connectivity-setup).
 
-<!--TODO for the Database Connectivity section, we could point to the Github README -->
-
-The Sidecar can connect to different types of databases. The current options are `SQLite` or `PostgreSQL`. The following sections show how to configure the database connection for one of these DBs. Note that the Sidecar can only connect to one DB at a time.
-
-#### SQLite Database
-
-This section includes configurations for the SQLite database.
-
-```
-[storage.sqlite_config]
-file_name = "sqlite_database.db3"
-max_connections_in_pool = 100
-# https://www.sqlite.org/compile.html#default_wal_autocheckpoint
-wal_autocheckpointing_interval = 1000
-```
-
-* `file_name` - The database file path.
-* `max_connections_in_pool` - The maximum number of connections to the database. (Should generally be left as is.)
-* `wal_autocheckpointing_interval` - This controls how often the system commits pages to the database. The value determines the maximum number of pages before forcing a commit. More information can be found [here](https://www.sqlite.org/compile.html#default_wal_autocheckpoint).
-
-#### PostgreSQL Database
-
-The properties listed below are elements of the PostgreSQL database connection that can be configured for the Sidecar.
-
-* `database_name` - Name of the database.
-* `host` - URL to PostgreSQL instance.
-* `database_username` - Username.
-* `database_password` - Database password.
-* `max_connections_in_pool` - The maximum number of connections to the database.
-* `port` - The port for the database connection.
-
-
-To run the Sidecar with PostgreSQL, you can set the following database environment variables to control how the Sidecar connects to the database. This is the suggested method to set the connection information for the PostgreSQL database.
-
-```
-SIDECAR_POSTGRES_USERNAME="your username"
-```
-
-```
-SIDECAR_POSTGRES_PASSWORD="your password"
-```
-
-```
-SIDECAR_POSTGRES_DATABASE_NAME="your database name"
-```
-
-```
-SIDECAR_POSTGRES_HOST="your host"
-```
-
-```
-SIDECAR_POSTGRES_MAX_CONNECTIONS="max connections"
-```
-
-```
-SIDECAR_POSTGRES_PORT="port"
-```
-
-However, DB connectivity can also be configured using the Sidecar configuration file.
-
-If the DB environment variables and the Sidecar's configuration file have the same variable set, the DB environment variables will take precedence.
-
-It is possible to completely omit the PostgreSQL configuration from the Sidecar's configuration file. In this case, the Sidecar will attempt to connect to the PostgreSQL using the database environment variables or use some default values for non-critical variables.
-
-```
-[storage.postgresql_config]
-database_name = "event_sidecar"
-host = "localhost"
-database_password = "p@$$w0rd"
-database_username = "postgres"
-max_connections_in_pool = 30
-```
-
-### REST & Event Stream Criteria
-
-This information determines outbound connection criteria for the Sidecar's `rest_server`.
-
-<!--TODO for the REST & Event Stream Criteria section, we could point to the Github README -->
-
-```
-[rest_api_server]
-port = 18888
-max_concurrent_requests = 50
-max_requests_per_second = 50
-request_timeout_in_seconds = 10
-```
-
-* `port` - The port for accessing the Sidecar's `rest_server`. `18888` is the default, but operators are free to choose their own port as needed.
-* `max_concurrent_requests` - The maximum total number of simultaneous requests that can be made to the REST server.
-* `max_requests_per_second` - The maximum total number of requests that can be made per second.
-* `request_timeout_in_seconds` - The total time before a request times out.
-
-```
-[event_stream_server]
-port = 19999
-max_concurrent_subscribers = 100
-event_stream_buffer_length = 5000
-```
-
-The `event_stream_server` section specifies a port for the Sidecar's event stream.
-
-Additionally, there are the following two options:
-
-* `max_concurrent_subscribers` - The maximum number of subscribers that can monitor the Sidecar's event stream.
-* `event_stream_buffer_length` - The number of events that the stream will hold in its buffer for reference when a subscriber reconnects.
-
-### Admin Server
-
-<!--TODO for the Admin Server section, we could point to the Github README -->
-
-This optional section configures the Sidecar's administrative REST server. If this section is not specified, the Sidecar will not start an admin server.
-
-```
-[admin_api_server]
-port = 18887
-max_concurrent_requests = 1
-max_requests_per_second = 1
-```
-
-* `port` - The port for accessing the Sidecar's admin REST server.
-* `max_concurrent_requests` - The maximum total number of simultaneous requests that can be sent to the admin server.
-* `max_requests_per_second` - The maximum total number of requests that can be sent per second to the admin server.
-
-Access the admin server at `http://localhost:18887/metrics/`.
-
-## Swagger Documentation
-
-Once the Sidecar is running, access the Swagger documentation at `http://localhost:18888/swagger-ui/`.
-
-## OpenAPI Specification
-
-An OpenAPI schema is available at `http://localhost:18888/api-doc.json/`.
-
-## Running the Event Sidecar
+## Running the Sidecar on a Node
 
 The `casper-sidecar` service starts after installation, using the systemd service file.
 
@@ -235,3 +41,11 @@ The `casper-sidecar` service starts after installation, using the systemd servic
 ### Logs
 
 `journalctl --no-pager -u casper-sidecar`
+
+## Swagger Documentation
+
+If the Sidecar is running locally, access the Swagger documentation at `http://localhost:18888/swagger-ui/`.
+
+## OpenAPI Specification
+
+An OpenAPI schema is available at `http://localhost:18888/api-doc.json/`.

--- a/resources/ETC_README.md
+++ b/resources/ETC_README.md
@@ -19,7 +19,7 @@ For more information, including how to setup the SSE, RPC, REST, and Admin serve
 
 This directory stores the SSE cache and a database if the Sidecar was configured to use one.
 
-```
+```toml
 [storage]
 storage_path = "/var/lib/casper-sidecar"
 ```

--- a/resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
@@ -1,3 +1,34 @@
+[rpc_server.main_server]
+enable_server = true
+address = "0.0.0.0:11102"
+qps_limit = 100
+max_body_bytes = 2621440
+cors_origin = ""
+
+[rpc_server.speculative_exec_server]
+enable_server = true
+address = "0.0.0.0:25102"
+qps_limit = 1
+max_body_bytes = 2621440
+cors_origin = ""
+
+[rpc_server.node_client]
+address = "0.0.0.0:28102"
+max_message_size_bytes = 4194304
+request_limit = 3
+request_buffer_size = 16
+message_timeout_secs = 30
+client_access_timeout_secs = 2
+
+[rpc_server.node_client.exponential_backoff]
+initial_delay_ms = 1000
+max_delay_ms = 32000
+coefficient = 2
+max_attempts = 30
+
+[sse_server]
+enable_server = true
+
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
 sse_port = 18101
@@ -6,6 +37,8 @@ max_attempts = 10
 delay_between_retries_in_seconds = 5
 allow_partial_connection = false
 enable_logging = true
+no_message_timeout_in_seconds = 10
+sleep_between_keep_alive_checks_in_seconds = 5
 
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
@@ -15,6 +48,8 @@ max_attempts = 10
 delay_between_retries_in_seconds = 5
 allow_partial_connection = false
 enable_logging = false
+no_message_timeout_in_seconds = 10
+sleep_between_keep_alive_checks_in_seconds = 5
 
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
@@ -25,6 +60,8 @@ delay_between_retries_in_seconds = 5
 allow_partial_connection = false
 enable_logging = false
 connection_timeout_in_seconds = 3
+no_message_timeout_in_seconds = 10
+sleep_between_keep_alive_checks_in_seconds = 5
 
 [sse_server.event_stream_server]
 port = 19999

--- a/resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml
@@ -1,3 +1,34 @@
+[rpc_server.main_server]
+enable_server = true
+address = "0.0.0.0:11102"
+qps_limit = 100
+max_body_bytes = 2621440
+cors_origin = ""
+
+[rpc_server.speculative_exec_server]
+enable_server = true
+address = "0.0.0.0:25102"
+qps_limit = 1
+max_body_bytes = 2621440
+cors_origin = ""
+
+[rpc_server.node_client]
+address = "0.0.0.0:28102"
+max_message_size_bytes = 4194304
+request_limit = 3
+request_buffer_size = 16
+message_timeout_secs = 30
+client_access_timeout_secs = 2
+
+[rpc_server.node_client.exponential_backoff]
+initial_delay_ms = 1000
+max_delay_ms = 32000
+coefficient = 2
+max_attempts = 30
+
+[sse_server]
+enable_server = true
+
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
 sse_port = 18101
@@ -6,6 +37,8 @@ max_attempts = 10
 delay_between_retries_in_seconds = 5
 allow_partial_connection = false
 enable_logging = true
+no_message_timeout_in_seconds = 10
+sleep_between_keep_alive_checks_in_seconds = 5
 
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
@@ -15,6 +48,8 @@ max_attempts = 10
 delay_between_retries_in_seconds = 5
 allow_partial_connection = false
 enable_logging = false
+no_message_timeout_in_seconds = 10
+sleep_between_keep_alive_checks_in_seconds = 5
 
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
@@ -25,6 +60,8 @@ delay_between_retries_in_seconds = 5
 allow_partial_connection = false
 enable_logging = false
 connection_timeout_in_seconds = 3
+no_message_timeout_in_seconds = 10
+sleep_between_keep_alive_checks_in_seconds = 5
 
 [sse_server.event_stream_server]
 port = 19999
@@ -45,3 +82,8 @@ max_connections_in_pool = 30
 port = 18888
 max_concurrent_requests = 50
 max_requests_per_second = 50
+
+[admin_api_server]
+port = 18887
+max_concurrent_requests = 1
+max_requests_per_second = 1

--- a/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
@@ -1,29 +1,66 @@
+[rpc_server.main_server]
+enable_server = true
+address = "0.0.0.0:7777"
+qps_limit = 100
+max_body_bytes = 2621440
+cors_origin = ""
+
+[rpc_server.speculative_exec_server]
+enable_server = true
+address = "0.0.0.0:7778"
+qps_limit = 1
+max_body_bytes = 2621440
+cors_origin = ""
+
+[rpc_server.node_client]
+address = "3.20.57.210:7777"
+max_message_size_bytes = 4194304
+request_limit = 10
+request_buffer_size = 50
+message_timeout_secs = 60
+client_access_timeout_secs = 60
+
+[rpc_server.node_client.exponential_backoff]
+initial_delay_ms = 1000
+max_delay_ms = 32000
+coefficient = 2
+max_attempts = 30
+
+[sse_server]
+enable_server = true
+
 [[sse_server.connections]]
-ip_address = "127.0.0.1"
+ip_address = "168.254.51.1"
 sse_port = 9999
 rest_port = 8888
-max_attempts = 10
-delay_between_retries_in_seconds = 5
-allow_partial_connection = false
-enable_logging = true
+max_attempts = 100
+delay_between_retries_in_seconds = 10
+allow_partial_connection = true
+enable_logging = false
+no_message_timeout_in_seconds = 20
+sleep_between_keep_alive_checks_in_seconds = 10
 
 [[sse_server.connections]]
 ip_address = "168.254.51.2"
 sse_port = 9999
 rest_port = 8888
-max_attempts = 10
-delay_between_retries_in_seconds = 5
+max_attempts = 100
+delay_between_retries_in_seconds = 10
 allow_partial_connection = false
-enable_logging = true
+enable_logging = false
+no_message_timeout_in_seconds = 20
+sleep_between_keep_alive_checks_in_seconds = 10
 
 [[sse_server.connections]]
 ip_address = "168.254.51.3"
 sse_port = 9999
 rest_port = 8888
-max_attempts = 10
-delay_between_retries_in_seconds = 5
+max_attempts = 100
+delay_between_retries_in_seconds = 10
 allow_partial_connection = false
-enable_logging = true
+enable_logging = false
+no_message_timeout_in_seconds = 20
+sleep_between_keep_alive_checks_in_seconds = 10
 
 [sse_server.event_stream_server]
 port = 19999

--- a/rpc_sidecar/README.md
+++ b/rpc_sidecar/README.md
@@ -8,22 +8,21 @@
 
 ## Synopsis
 
-The Casper Sidecar is a process that connects to the RPC port of a Casper node and exposes a JSON-RPC interface for interacting with that node. The RPC protocol allows for basic operations like querying global state, sending transactions and deploys, etc. All of the RPC methods are documented [here](https://docs.casper.network/developers/json-rpc/).
+The Casper Sidecar provides connectivity to the binary port of a Casper node (among [other capabilities](../README.md#system-components-and-architecture)), exposing a JSON-RPC interface for interacting with that node. The RPC protocol allows for basic operations like querying global state, sending transactions and deploys, etc. All of the available RPC methods are documented [here](https://docs.casper.network/developers/json-rpc/).
 
 ## Protocol
-The sidecar maintains a TCP connection with the node and communicates using a custom binary protocol built on top of [Juliet](https://github.com/casper-network/juliet). The protocol uses a request-response model where the sidecar sends simple self-contained requests and the node responds to them. The requests can be split into these main categories:
-- read requests
-    - queries for transient in-memory information like the 
-      current block height, peer list, component status etc.
-    - queries for database items, with both the database and the key 
-      always being explicitly specified by the sidecar
-- execute transaction requests
-    - request to submit a transaction for execution
-    - request to speculatively execute a transaction 
+
+The Sidecar maintains a TCP connection with the node and communicates using a custom binary protocol, which uses a request-response model. The Sidecar sends simple self-contained requests and the node responds to them. The requests can be split into these main categories:
+- Read requests
+    - Queries for transient in-memory information like the current block height, peer list, component status etc.
+    - Queries for database items, with both the database and the key always being explicitly specified by the sidecar
+- Transaction requests
+    - Requests to submit transactions for execution
+    - Requests to speculatively execute a transactions 
 
 ## Discovering the JSON RPC API
 
-Once running, the Sidecar can be queried for its JSON RPC API using the `rpc.discover` method, as shown below. The result will be a list of RPC methods and their parameters.
+Once setup and running as described [here](../README.md), the Sidecar can be queried for its JSON RPC API using the `rpc.discover` method, as shown below. The result will be a list of RPC methods and their parameters.
 
 ```bash
 curl -X POST http://localhost:<RPC_SERVER_PORT>/rpc -H 'Content-Type: application/json' -d '{"jsonrpc": "2.0", "method": "rpc.discover", "id": 1}'

--- a/rpc_sidecar/README.md
+++ b/rpc_sidecar/README.md
@@ -8,7 +8,7 @@
 
 ## Synopsis
 
-The Casper Event Sidecar is a process that connects to the RPC port of a Casper node and exposes a JSON-RPC interface for interacting with that node. The RPC protocol allows for basic operations like querying global state, sending transactions and deploys, etc. All of the RPC methods are documented [here](https://docs.casper.network/developers/json-rpc/).
+The Casper Sidecar is a process that connects to the RPC port of a Casper node and exposes a JSON-RPC interface for interacting with that node. The RPC protocol allows for basic operations like querying global state, sending transactions and deploys, etc. All of the RPC methods are documented [here](https://docs.casper.network/developers/json-rpc/).
 
 ## Protocol
 The sidecar maintains a TCP connection with the node and communicates using a custom binary protocol built on top of [Juliet](https://github.com/casper-network/juliet). The protocol uses a request-response model where the sidecar sends simple self-contained requests and the node responds to them. The requests can be split into these main categories:

--- a/rpc_sidecar/README.md
+++ b/rpc_sidecar/README.md
@@ -22,7 +22,7 @@ The Sidecar maintains a TCP connection with the node and communicates using a cu
 
 ## Discovering the JSON RPC API
 
-Once setup and running as described [here](../README.md), the Sidecar can be queried for its JSON RPC API using the `rpc.discover` method, as shown below. The result will be a list of RPC methods and their parameters.
+Once setup and running as described [here](../README.md), the Sidecar can be queried for its JSON-RPC API using the `rpc.discover` method, as shown below. The result will be a list of RPC methods and their parameters.
 
 ```bash
 curl -X POST http://localhost:<RPC_SERVER_PORT>/rpc -H 'Content-Type: application/json' -d '{"jsonrpc": "2.0", "method": "rpc.discover", "id": 1}'

--- a/rpc_sidecar/README.md
+++ b/rpc_sidecar/README.md
@@ -24,7 +24,7 @@ The Sidecar maintains a TCP connection with the node and communicates using a cu
 
 Once setup and running as described [here](../README.md), the Sidecar can be queried for its JSON-RPC API using the `rpc.discover` method, as shown below. The result will be a list of RPC methods and their parameters.
 
-```bash
+```sh
 curl -X POST http://localhost:<RPC_SERVER_PORT>/rpc -H 'Content-Type: application/json' -d '{"jsonrpc": "2.0", "method": "rpc.discover", "id": 1}'
 ```
 

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -45,7 +45,7 @@ assets = [
 ]
 maintainer-scripts = "../resources/maintainer_scripts/debian"
 extended-description = """
-Package for Casper Event Sidecar
+Package for Casper Sidecar
 """
 
 [package.metadata.deb.systemd-units]


### PR DESCRIPTION
I'd like to submit this PR to clarify the flow and condense the content in the READMEs.

- Updated example config files based on a file received from JZ. 
- Removed duplicated content in the ETC_README.md file. Kept only operator-specific instructions in this file.
- Cleaned up the rpc_sidecar/README.md file.
- Added a logo & license to the main README file.
- I re-arranged the content for better flow and did some minor edits.

Anyone who is active on the project is welcome to review this PR. Thanks!