### PR TITLE
Bump casper-node dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#6500496a548d8a327cd93625dda7139804e22210"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#44e67cdf1cb22e0f4dccd75199e3c337b1ddaa4e"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#6500496a548d8a327cd93625dda7139804e22210"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#44e67cdf1cb22e0f4dccd75199e3c337b1ddaa4e"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#39dcb74d97879321a9008e238cb11bb4b5276c68"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#6500496a548d8a327cd93625dda7139804e22210"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#39dcb74d97879321a9008e238cb11bb4b5276c68"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#6500496a548d8a327cd93625dda7139804e22210"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -4834,6 +4834,19 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "Credited amount.",
+            "type": "object",
+            "required": [
+              "Credit"
+            ],
+            "properties": {
+              "Credit": {
+                "$ref": "#/components/schemas/ValidatorCredit"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -4926,6 +4939,42 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/EraId"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValidatorCredit": {
+        "description": "Validator credit record.",
+        "type": "object",
+        "required": [
+          "amount",
+          "era_id",
+          "validator_public_key"
+        ],
+        "properties": {
+          "validator_public_key": {
+            "description": "Validator public key",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "era_id": {
+            "description": "The era id the credit was created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EraId"
+              }
+            ]
+          },
+          "amount": {
+            "description": "The credit amount.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/U512"
               }
             ]
           }

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -2923,6 +2923,19 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "Credited amount.",
+            "type": "object",
+            "required": [
+              "Credit"
+            ],
+            "properties": {
+              "Credit": {
+                "$ref": "#/components/schemas/ValidatorCredit"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -3015,6 +3028,42 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/EraId"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValidatorCredit": {
+        "description": "Validator credit record.",
+        "type": "object",
+        "required": [
+          "amount",
+          "era_id",
+          "validator_public_key"
+        ],
+        "properties": {
+          "validator_public_key": {
+            "description": "Validator public key",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicKey"
+              }
+            ]
+          },
+          "era_id": {
+            "description": "The era id the credit was created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EraId"
+              }
+            ]
+          },
+          "amount": {
+            "description": "The credit amount.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/U512"
               }
             ]
           }


### PR DESCRIPTION
Nightly tests are broken again because there was a minor change in `StoredValue`, this updates casper-types to pull the latest one and fix the tests