### PR TITLE
Deprecation notice

### DIFF
--- a/LEGACY_SSE_EMULATION.md
+++ b/LEGACY_SSE_EMULATION.md
@@ -8,7 +8,7 @@ SSE emulation is by default turned off, the instruction on how to enable it is i
 
 **BEFORE YOU ENABLE LEGACY SSE EMULATION** please consider the following:
 
-- The legacy SSE emulation is a temporary solution and can be removed in a future major release.
+- The legacy SSE emulation is a temporary solution and can be removed in a future major release. Consider it being _deprecated_.
 - The legacy SSE emulation is not a 1:1 mapping of the 2.x events to 1.x events. Some events will be omitted, some will be transformed, some will be passed as is. More details on the limitations of the emulation are explained below.
 - The legacy SSE emulation is an additional drain on resources. It will consume more resources than the "native" 2.x SSE API.
 


### PR DESCRIPTION
When connecting to one of the legacy endpoints:
* /events/main
* /events/sigs
* /events/deploys
The first data coming off the node from now on is a comment which is a deprecation notice. The event stream should look something like:
```
:This endpoint is NOT a 1 to 1 representation of events coming off of the node. Some events are not transformable to legacy format. Please consult the documentation for details. This endpoint is deprecated and will be removed in a future release. Please migrate to the /events endpoint instead.

data:{"ApiVersion":"2.0.0"}
```