### PR TITLE
Introduce Request Id for binary port communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,6 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#44e67cdf1cb22e0f4dccd75199e3c337b1ddaa4e"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +669,6 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#44e67cdf1cb22e0f4dccd75199e3c337b1ddaa4e"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#d15d2a15c95594cbe84016cd87db5f726c3349a1"
+source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#62e9eee0a3b5aeaa3debac06bde76419c0b0ac89"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#d15d2a15c95594cbe84016cd87db5f726c3349a1"
+source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#62e9eee0a3b5aeaa3debac06bde76419c0b0ac89"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#ae8a555ac677005402cb6d7688bb1faee03f9b4b"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#d15d2a15c95594cbe84016cd87db5f726c3349a1"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#ae8a555ac677005402cb6d7688bb1faee03f9b4b"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#d15d2a15c95594cbe84016cd87db5f726c3349a1"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#298518cae099c67a09b76c532ed3a9c09ff75296"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#93974105e0ee2ce152891465e0f7661c701c0396"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#298518cae099c67a09b76c532ed3a9c09ff75296"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#93974105e0ee2ce152891465e0f7661c701c0396"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#caae87b0473987f31d965ca8e59cc3cac9b79ff2"
+source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#6b3041c49f177d97dd338c450f98f65f640cc34a"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#caae87b0473987f31d965ca8e59cc3cac9b79ff2"
+source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#6b3041c49f177d97dd338c450f98f65f640cc34a"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
+source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#caae87b0473987f31d965ca8e59cc3cac9b79ff2"
 dependencies = [
  "bincode",
  "bytes",
@@ -669,6 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
+source = "git+https://github.com/rafal-ch/casper-node.git?branch=binary_port_fixes#caae87b0473987f31d965ca8e59cc3cac9b79ff2"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [
 anyhow = "1"
 async-stream = "0.3.4"
 async-trait = "0.1.77"
-casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-types = { git = "https://github.com/rafal-ch/casper-node.git", branch = "binary_port_fixes" }
+casper-binary-port = { git = "https://github.com/rafal-ch/casper-node.git", branch = "binary_port_fixes" }
 casper-event-sidecar = { path = "./event_sidecar", version = "1.0.0" }
 casper-event-types = { path = "./types", version = "1.0.0" }
 casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [
 anyhow = "1"
 async-stream = "0.3.4"
 async-trait = "0.1.77"
-casper-types = { git = "https://github.com/rafal-ch/casper-node.git", branch = "binary_port_fixes" }
-casper-binary-port = { git = "https://github.com/rafal-ch/casper-node.git", branch = "binary_port_fixes" }
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
 casper-event-sidecar = { path = "./event_sidecar", version = "1.0.0" }
 casper-event-types = { path = "./types", version = "1.0.0" }
 casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [
 anyhow = "1"
 async-stream = "0.3.4"
 async-trait = "0.1.77"
-casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0"  }
+casper-types = { git = "https://github.com/rafal-ch/casper-node.git", branch = "binary_port_fixes" }
+casper-binary-port = { git = "https://github.com/rafal-ch/casper-node.git", branch = "binary_port_fixes"  }
 casper-event-sidecar = { path = "./event_sidecar", version = "1.0.0" }
 casper-event-types = { path = "./types", version = "1.0.0" }
 casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }
@@ -31,7 +31,3 @@ toml = "0.5.8"
 tracing = { version = "0", default-features = false }
 tracing-subscriber = "0"
 serde = { version = "1", default-features = false }
-
-[patch.'https://github.com/casper-network/casper-node.git']
-casper-binary-port = { path = "../casper-node/binary_port" }
-casper-types = { path = "../casper-node/types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ toml = "0.5.8"
 tracing = { version = "0", default-features = false }
 tracing-subscriber = "0"
 serde = { version = "1", default-features = false }
+
+[patch.'https://github.com/casper-network/casper-node.git']
+casper-binary-port = { path = "../casper-node/binary_port" }
+casper-types = { path = "../casper-node/types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [
 anyhow = "1"
 async-stream = "0.3.4"
 async-trait = "0.1.77"
-casper-types = { git = "https://github.com/rafal-ch/casper-node.git", branch = "binary_port_fixes" }
-casper-binary-port = { git = "https://github.com/rafal-ch/casper-node.git", branch = "binary_port_fixes"  }
+casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-binary-port = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
 casper-event-sidecar = { path = "./event_sidecar", version = "1.0.0" }
 casper-event-types = { path = "./types", version = "1.0.0" }
 casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -222,7 +222,7 @@
                     ],
                     "target": "Native",
                     "entry_point": "Transfer",
-                    "transaction_kind": 0,
+                    "transaction_category": 0,
                     "scheduling": "Standard"
                   },
                   "approvals": [
@@ -557,7 +557,7 @@
                     ],
                     "target": "Native",
                     "entry_point": "Transfer",
-                    "transaction_kind": 0,
+                    "transaction_category": 0,
                     "scheduling": "Standard"
                   },
                   "approvals": [
@@ -3259,7 +3259,7 @@
             "additionalProperties": false
           },
           {
-            "description": "The cost of the transaction is determined by the cost table, per the transaction kind.",
+            "description": "The cost of the transaction is determined by the cost table, per the transaction category.",
             "type": "object",
             "required": [
               "Fixed"
@@ -3355,7 +3355,7 @@
           "entry_point",
           "scheduling",
           "target",
-          "transaction_kind"
+          "transaction_category"
         ],
         "properties": {
           "args": {
@@ -3367,7 +3367,7 @@
           "entry_point": {
             "$ref": "#/components/schemas/TransactionEntryPoint"
           },
-          "transaction_kind": {
+          "transaction_category": {
             "type": "integer",
             "format": "uint8",
             "minimum": 0.0
@@ -3434,19 +3434,10 @@
               "Session": {
                 "type": "object",
                 "required": [
-                  "kind",
                   "module_bytes",
                   "runtime"
                 ],
                 "properties": {
-                  "kind": {
-                    "description": "The kind of session.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/TransactionSessionKind"
-                      }
-                    ]
-                  },
                   "module_bytes": {
                     "description": "The compiled Wasm.",
                     "allOf": [
@@ -3581,39 +3572,6 @@
             "type": "string",
             "enum": [
               "VmCasperV2"
-            ]
-          }
-        ]
-      },
-      "TransactionSessionKind": {
-        "description": "Session kind of a Transaction.",
-        "oneOf": [
-          {
-            "description": "A standard (non-special-case) session.\n\nThis kind of session is not allowed to install or upgrade a stored contract, but can call stored contracts.",
-            "type": "string",
-            "enum": [
-              "Standard"
-            ]
-          },
-          {
-            "description": "A session which installs a stored contract.",
-            "type": "string",
-            "enum": [
-              "Installer"
-            ]
-          },
-          {
-            "description": "A session which upgrades a previously-installed stored contract.  Such a session must have \"package_id: PackageIdentifier\" runtime arg present.",
-            "type": "string",
-            "enum": [
-              "Upgrader"
-            ]
-          },
-          {
-            "description": "A session which doesn't call any stored contracts.\n\nThis kind of session is not allowed to install or upgrade a stored contract.",
-            "type": "string",
-            "enum": [
-              "Isolated"
             ]
           }
         ]

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -4972,6 +4972,8 @@
           "bonding_purse",
           "delegation_rate",
           "inactive",
+          "maximum_delegation_amount",
+          "minimum_delegation_amount",
           "staked_amount",
           "validator_public_key"
         ],
@@ -5020,6 +5022,18 @@
           "inactive": {
             "description": "`true` if validator has been \"evicted\"",
             "type": "boolean"
+          },
+          "minimum_delegation_amount": {
+            "description": "Minimum allowed delegation amount in motes",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "maximum_delegation_amount": {
+            "description": "Maximum allowed delegation amount in motes",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -230,7 +230,7 @@
                     ],
                     "target": "Native",
                     "entry_point": "Transfer",
-                    "transaction_kind": 0,
+                    "transaction_category": 0,
                     "scheduling": "Standard"
                   },
                   "approvals": [
@@ -3777,7 +3777,7 @@
             "additionalProperties": false
           },
           {
-            "description": "The cost of the transaction is determined by the cost table, per the transaction kind.",
+            "description": "The cost of the transaction is determined by the cost table, per the transaction category.",
             "type": "object",
             "required": [
               "Fixed"
@@ -3838,7 +3838,7 @@
           "entry_point",
           "scheduling",
           "target",
-          "transaction_kind"
+          "transaction_category"
         ],
         "properties": {
           "args": {
@@ -3850,7 +3850,7 @@
           "entry_point": {
             "$ref": "#/components/schemas/TransactionEntryPoint"
           },
-          "transaction_kind": {
+          "transaction_category": {
             "type": "integer",
             "format": "uint8",
             "minimum": 0.0
@@ -3917,19 +3917,10 @@
               "Session": {
                 "type": "object",
                 "required": [
-                  "kind",
                   "module_bytes",
                   "runtime"
                 ],
                 "properties": {
-                  "kind": {
-                    "description": "The kind of session.",
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/TransactionSessionKind"
-                      }
-                    ]
-                  },
                   "module_bytes": {
                     "description": "The compiled Wasm.",
                     "allOf": [
@@ -4046,39 +4037,6 @@
               }
             },
             "additionalProperties": false
-          }
-        ]
-      },
-      "TransactionSessionKind": {
-        "description": "Session kind of a Transaction.",
-        "oneOf": [
-          {
-            "description": "A standard (non-special-case) session.\n\nThis kind of session is not allowed to install or upgrade a stored contract, but can call stored contracts.",
-            "type": "string",
-            "enum": [
-              "Standard"
-            ]
-          },
-          {
-            "description": "A session which installs a stored contract.",
-            "type": "string",
-            "enum": [
-              "Installer"
-            ]
-          },
-          {
-            "description": "A session which upgrades a previously-installed stored contract.  Such a session must have \"package_id: PackageIdentifier\" runtime arg present.",
-            "type": "string",
-            "enum": [
-              "Upgrader"
-            ]
-          },
-          {
-            "description": "A session which doesn't call any stored contracts.\n\nThis kind of session is not allowed to install or upgrade a stored contract.",
-            "type": "string",
-            "enum": [
-              "Isolated"
-            ]
           }
         ]
       },

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -2947,6 +2947,8 @@
           "bonding_purse",
           "delegation_rate",
           "inactive",
+          "maximum_delegation_amount",
+          "minimum_delegation_amount",
           "staked_amount",
           "validator_public_key"
         ],
@@ -2995,6 +2997,18 @@
           "inactive": {
             "description": "`true` if validator has been \"evicted\"",
             "type": "boolean"
+          },
+          "minimum_delegation_amount": {
+            "description": "Minimum allowed delegation amount in motes",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "maximum_delegation_amount": {
+            "description": "Maximum allowed delegation amount in motes",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false

--- a/rpc_sidecar/src/lib.rs
+++ b/rpc_sidecar/src/lib.rs
@@ -118,7 +118,7 @@ fn resolve_address(address: &str) -> anyhow::Result<SocketAddr> {
         .ok_or_else(|| anyhow::anyhow!("failed to resolve address"))
 }
 
-fn encode_request(req: &BinaryRequest, id: u64) -> Result<Vec<u8>, bytesrepr::Error> {
+fn encode_request(req: &BinaryRequest, id: u16) -> Result<Vec<u8>, bytesrepr::Error> {
     let header = BinaryRequestHeader::new(SUPPORTED_PROTOCOL_VERSION, req.tag(), id);
     let mut bytes = Vec::with_capacity(header.serialized_length() + req.serialized_length());
     header.write_bytes(&mut bytes)?;

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -1149,13 +1149,13 @@ mod tests {
         let port = get_port();
         let config = NodeClientConfig::new_with_port(port);
         let shutdown = Arc::new(tokio::sync::Notify::new());
-        let _ = start_mock_binary_port(port, vec![], 1, Arc::clone(&shutdown)).await;
+        let _mock_server_handle = start_mock_binary_port(port, vec![], 1, Arc::clone(&shutdown)).await;
         let (c, _) = FramedNodeClient::new(config).await.unwrap();
 
         let generated_ids: Vec<_> = (INITIAL_REQUEST_ID..INITIAL_REQUEST_ID + 10)
             .map(|_| {
                 let (_, binary_message) = c.generate_payload(get_dummy_request());
-                let header = BinaryRequestHeader::from_bytes(&binary_message.payload())
+                let header = BinaryRequestHeader::from_bytes(binary_message.payload())
                     .unwrap()
                     .0;
                 header.id()

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -15,8 +15,8 @@ use std::{
 use tokio_util::codec::Framed;
 
 use casper_binary_port::{
-    BalanceResponse, BinaryMessage, BinaryMessageCodec, BinaryRequest, BinaryRequestHeader,
-    BinaryResponse, BinaryResponseAndRequest, ConsensusValidatorChanges, DictionaryItemIdentifier,
+    BalanceResponse, BinaryMessage, BinaryMessageCodec, BinaryRequest, BinaryResponse,
+    BinaryResponseAndRequest, ConsensusValidatorChanges, DictionaryItemIdentifier,
     DictionaryQueryResult, ErrorCode, GetRequest, GetTrieFullResult, GlobalStateQueryResult,
     GlobalStateRequest, InformationRequest, KeyPrefix, NodeStatus, PayloadEntity, PurseIdentifier,
     RecordId, SpeculativeExecutionResult, TransactionWithExecutionInfo,
@@ -912,6 +912,7 @@ mod tests {
     };
 
     use super::*;
+    use casper_binary_port::BinaryRequestHeader;
     use casper_types::testing::TestRng;
     use casper_types::{CLValue, SemVer};
     use futures::FutureExt;
@@ -928,6 +929,7 @@ mod tests {
             BinaryResponseAndRequest::new(
                 BinaryResponse::from_value(AvailableBlockRange::RANGE_0_0, bad_version),
                 &request,
+                0,
             ),
             0,
             &notify,
@@ -951,6 +953,7 @@ mod tests {
             BinaryResponseAndRequest::new(
                 BinaryResponse::from_value(AvailableBlockRange::RANGE_0_0, version),
                 &request,
+                0,
             ),
             0,
             &notify,
@@ -960,7 +963,8 @@ mod tests {
             result,
             Ok(BinaryResponseAndRequest::new(
                 BinaryResponse::from_value(AvailableBlockRange::RANGE_0_0, version),
-                &request
+                &request,
+                0
             ))
         );
         assert_eq!(notify.notified().now_or_never(), None)
@@ -980,6 +984,7 @@ mod tests {
             BinaryResponseAndRequest::new(
                 BinaryResponse::from_value(AvailableBlockRange::RANGE_0_0, version),
                 &request,
+                0,
             ),
             0,
             &notify,
@@ -989,7 +994,8 @@ mod tests {
             result,
             Ok(BinaryResponseAndRequest::new(
                 BinaryResponse::from_value(AvailableBlockRange::RANGE_0_0, version),
-                &request
+                &request,
+                0
             ))
         );
         assert_eq!(notify.notified().now_or_never(), None)
@@ -1149,7 +1155,7 @@ mod tests {
 
         let req = get_dummy_request_payload(Some(actual_id));
         let resp = BinaryResponse::new_empty(ProtocolVersion::V2_0_0);
-        let resp_and_req = BinaryResponseAndRequest::new(resp, &req);
+        let resp_and_req = BinaryResponseAndRequest::new(resp, &req, actual_id);
 
         let result = validate_response(resp_and_req, expected_id, &notify);
         assert!(matches!(
@@ -1162,7 +1168,7 @@ mod tests {
 
         let req = get_dummy_request_payload(Some(actual_id));
         let resp = BinaryResponse::new_empty(ProtocolVersion::V2_0_0);
-        let resp_and_req = BinaryResponseAndRequest::new(resp, &req);
+        let resp_and_req = BinaryResponseAndRequest::new(resp, &req, actual_id);
 
         let result = validate_response(resp_and_req, expected_id, &notify);
         assert!(matches!(
@@ -1180,7 +1186,7 @@ mod tests {
 
         let req = get_dummy_request_payload(Some(actual_id));
         let resp = BinaryResponse::new_empty(ProtocolVersion::V2_0_0);
-        let resp_and_req = BinaryResponseAndRequest::new(resp, &req);
+        let resp_and_req = BinaryResponseAndRequest::new(resp, &req, actual_id);
 
         let result = validate_response(resp_and_req, expected_id, &notify);
         dbg!(&result);

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -515,11 +515,11 @@ pub enum Error {
     #[error("received a response with an unsupported protocol version: {0}")]
     UnsupportedProtocolVersion(ProtocolVersion),
     #[error("received an unexpected node error: {message} ({code})")]
-    UnexpectedNodeError { message: String, code: u8 },
+    UnexpectedNodeError { message: String, code: u16 },
 }
 
 impl Error {
-    fn from_error_code(code: u8) -> Self {
+    fn from_error_code(code: u16) -> Self {
         match ErrorCode::try_from(code) {
             Ok(ErrorCode::FunctionDisabled) => Self::FunctionIsDisabled,
             Ok(ErrorCode::RootNotFound) => Self::UnknownStateRootHash,

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -1149,7 +1149,8 @@ mod tests {
         let port = get_port();
         let config = NodeClientConfig::new_with_port(port);
         let shutdown = Arc::new(tokio::sync::Notify::new());
-        let _mock_server_handle = start_mock_binary_port(port, vec![], 1, Arc::clone(&shutdown)).await;
+        let _mock_server_handle =
+            start_mock_binary_port(port, vec![], 1, Arc::clone(&shutdown)).await;
         let (c, _) = FramedNodeClient::new(config).await.unwrap();
 
         let generated_ids: Vec<_> = (INITIAL_REQUEST_ID..INITIAL_REQUEST_ID + 10)

--- a/rpc_sidecar/src/rpcs/account.rs
+++ b/rpc_sidecar/src/rpcs/account.rs
@@ -172,6 +172,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::new_empty(SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     _ => unimplemented!(),
@@ -213,6 +214,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::new_empty(SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     _ => unimplemented!(),
@@ -257,6 +259,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     _ => unimplemented!(),

--- a/rpc_sidecar/src/rpcs/chain.rs
+++ b/rpc_sidecar/src/rpcs/chain.rs
@@ -704,6 +704,7 @@ mod tests {
                     Ok(BinaryResponseAndRequest::new(
                         BinaryResponse::from_value(self.block.clone(), SUPPORTED_PROTOCOL_VERSION),
                         &[],
+                        0,
                     ))
                 }
                 BinaryRequest::Get(GetRequest::Information { info_type_tag, .. })
@@ -716,6 +717,7 @@ mod tests {
                             SUPPORTED_PROTOCOL_VERSION,
                         ),
                         &[],
+                        0,
                     ))
                 }
                 BinaryRequest::Get(GetRequest::Record {
@@ -758,6 +760,7 @@ mod tests {
                             SUPPORTED_PROTOCOL_VERSION,
                         ),
                         &[],
+                        0,
                     ))
                 }
                 BinaryRequest::Get(GetRequest::State(req))
@@ -778,6 +781,7 @@ mod tests {
                             SUPPORTED_PROTOCOL_VERSION,
                         ),
                         &[],
+                        0,
                     ))
                 }
                 req => unimplemented!("unexpected request: {:?}", req),

--- a/rpc_sidecar/src/rpcs/info.rs
+++ b/rpc_sidecar/src/rpcs/info.rs
@@ -757,6 +757,7 @@ mod tests {
                     Ok(BinaryResponseAndRequest::new(
                         BinaryResponse::from_value(transaction, SUPPORTED_PROTOCOL_VERSION),
                         &[],
+                        0,
                     ))
                 }
                 req => unimplemented!("unexpected request: {:?}", req),

--- a/rpc_sidecar/src/rpcs/speculative_exec.rs
+++ b/rpc_sidecar/src/rpcs/speculative_exec.rs
@@ -246,6 +246,7 @@ mod tests {
                             SUPPORTED_PROTOCOL_VERSION,
                         ),
                         &[],
+                        0,
                     ))
                 }
                 BinaryRequest::TrySpeculativeExec { .. } => Ok(BinaryResponseAndRequest::new(
@@ -254,6 +255,7 @@ mod tests {
                         SUPPORTED_PROTOCOL_VERSION,
                     ),
                     &[],
+                    0,
                 )),
                 req => unimplemented!("unexpected request: {:?}", req),
             }

--- a/rpc_sidecar/src/rpcs/state.rs
+++ b/rpc_sidecar/src/rpcs/state.rs
@@ -1260,6 +1260,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1280,6 +1281,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::from_value(bids, SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1300,6 +1302,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::from_value(bids, SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1321,6 +1324,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::from_value(result, SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1339,6 +1343,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::from_value(result, SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     req => unimplemented!("unexpected request: {:?}", req),
@@ -1405,6 +1410,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1425,6 +1431,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::from_value(bids, SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1445,6 +1452,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::from_value(bids, SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1468,6 +1476,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::from_value(result, SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1483,6 +1492,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::new_empty(SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1502,6 +1512,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::from_value(result, SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     req => unimplemented!("unexpected request: {:?}", req),
@@ -1559,6 +1570,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::new_empty(SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::Information { info_type_tag, .. })
@@ -1571,6 +1583,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     req => unimplemented!("unexpected request: {:?}", req),
@@ -1624,6 +1637,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1644,6 +1658,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1669,6 +1684,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1690,6 +1706,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1707,6 +1724,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     req => unimplemented!("unexpected request: {:?}", req),
@@ -1834,6 +1852,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1848,6 +1867,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::new_empty(SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     req => unimplemented!("unexpected request: {:?}", req),
@@ -1936,6 +1956,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -1959,6 +1980,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     req => unimplemented!("unexpected request: {:?}", req),
@@ -2010,6 +2032,7 @@ mod tests {
                                 SUPPORTED_PROTOCOL_VERSION,
                             ),
                             &[],
+                            0,
                         ))
                     }
                     BinaryRequest::Get(GetRequest::State(req))
@@ -2024,6 +2047,7 @@ mod tests {
                         Ok(BinaryResponseAndRequest::new(
                             BinaryResponse::new_empty(SUPPORTED_PROTOCOL_VERSION),
                             &[],
+                            0,
                         ))
                     }
                     req => unimplemented!("unexpected request: {:?}", req),
@@ -2220,6 +2244,7 @@ mod tests {
                             SUPPORTED_PROTOCOL_VERSION,
                         ),
                         &[],
+                        0,
                     ))
                 }
                 req => unimplemented!("unexpected request: {:?}", req),
@@ -2242,6 +2267,7 @@ mod tests {
                     Ok(BinaryResponseAndRequest::new(
                         BinaryResponse::from_value(self.0.clone(), SUPPORTED_PROTOCOL_VERSION),
                         &[],
+                        0,
                     ))
                 }
                 req => unimplemented!("unexpected request: {:?}", req),
@@ -2271,6 +2297,7 @@ mod tests {
                             SUPPORTED_PROTOCOL_VERSION,
                         ),
                         &[],
+                        0,
                     ))
                 }
                 BinaryRequest::Get(GetRequest::State(req))
@@ -2279,6 +2306,7 @@ mod tests {
                     Ok(BinaryResponseAndRequest::new(
                         BinaryResponse::from_value(self.result.clone(), SUPPORTED_PROTOCOL_VERSION),
                         &[],
+                        0,
                     ))
                 }
                 req => unimplemented!("unexpected request: {:?}", req),
@@ -2308,6 +2336,7 @@ mod tests {
                             SUPPORTED_PROTOCOL_VERSION,
                         ),
                         &[],
+                        0,
                     ))
                 }
                 BinaryRequest::Get(GetRequest::State(req))
@@ -2328,6 +2357,7 @@ mod tests {
                             SUPPORTED_PROTOCOL_VERSION,
                         ),
                         &[],
+                        0,
                     ))
                 }
                 req => unimplemented!("unexpected request: {:?}", req),
@@ -2350,6 +2380,7 @@ mod tests {
                     Ok(BinaryResponseAndRequest::new(
                         BinaryResponse::from_value(self.0.clone(), SUPPORTED_PROTOCOL_VERSION),
                         &[],
+                        0,
                     ))
                 }
                 req => unimplemented!("unexpected request: {:?}", req),

--- a/rpc_sidecar/src/testing/mod.rs
+++ b/rpc_sidecar/src/testing/mod.rs
@@ -85,7 +85,7 @@ pub async fn start_mock_binary_port_responding_with_stored_value(
     start_mock_binary_port(port, response.to_bytes().unwrap(), shutdown).await
 }
 
-async fn start_mock_binary_port(port: u16, data: Vec<u8>, shutdown: Arc<Notify>) -> JoinHandle<()> {
+pub async fn start_mock_binary_port(port: u16, data: Vec<u8>, shutdown: Arc<Notify>) -> JoinHandle<()> {
     let handler = tokio::spawn(async move {
         let binary_port = BinaryPortMock::new(port, data);
         binary_port.start(shutdown).await;

--- a/rpc_sidecar/src/testing/mod.rs
+++ b/rpc_sidecar/src/testing/mod.rs
@@ -77,7 +77,7 @@ pub fn get_port() -> u16 {
 
 pub async fn start_mock_binary_port_responding_with_stored_value(
     port: u16,
-    request_id: Option<u64>,
+    request_id: Option<u16>,
     shutdown: Arc<Notify>,
 ) -> JoinHandle<()> {
     let value = StoredValue::CLValue(CLValue::from_t("Foo").unwrap());
@@ -85,7 +85,7 @@ pub async fn start_mock_binary_port_responding_with_stored_value(
     let protocol_version = ProtocolVersion::from_parts(2, 0, 0);
     let val = BinaryResponse::from_value(data, protocol_version);
     let request = get_dummy_request_payload(request_id);
-    let response = BinaryResponseAndRequest::new(val, &request);
+    let response = BinaryResponseAndRequest::new(val, &request, request_id.unwrap_or_default());
     start_mock_binary_port(port, response.to_bytes().unwrap(), shutdown).await
 }
 
@@ -109,7 +109,7 @@ pub(crate) fn get_dummy_request() -> BinaryRequest {
     })
 }
 
-pub(crate) fn get_dummy_request_payload(request_id: Option<u64>) -> bytesrepr::Bytes {
+pub(crate) fn get_dummy_request_payload(request_id: Option<u16>) -> bytesrepr::Bytes {
     let dummy_request = get_dummy_request();
     encode_request(&dummy_request, request_id.unwrap_or_default())
         .unwrap()

--- a/rpc_sidecar/src/testing/mod.rs
+++ b/rpc_sidecar/src/testing/mod.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use casper_binary_port::{
-    BinaryMessage, BinaryMessageCodec, BinaryResponse, BinaryResponseAndRequest,
-    GlobalStateQueryResult,
+    BinaryMessage, BinaryMessageCodec, BinaryRequest, BinaryResponse, BinaryResponseAndRequest,
+    GetRequest, GlobalStateQueryResult,
 };
+use casper_types::bytesrepr;
 use casper_types::{bytesrepr::ToBytes, CLValue, ProtocolVersion, StoredValue};
 use futures::{SinkExt, StreamExt};
 use tokio::sync::Notify;
@@ -14,6 +15,8 @@ use tokio::{
     time::sleep,
 };
 use tokio_util::codec::Framed;
+
+use crate::encode_request;
 
 const LOCALHOST: &str = "127.0.0.1";
 const MESSAGE_SIZE: u32 = 1024 * 1024 * 10;
@@ -74,22 +77,41 @@ pub fn get_port() -> u16 {
 
 pub async fn start_mock_binary_port_responding_with_stored_value(
     port: u16,
+    request_id: Option<u64>,
     shutdown: Arc<Notify>,
 ) -> JoinHandle<()> {
     let value = StoredValue::CLValue(CLValue::from_t("Foo").unwrap());
     let data = GlobalStateQueryResult::new(value, vec![]);
     let protocol_version = ProtocolVersion::from_parts(2, 0, 0);
     let val = BinaryResponse::from_value(data, protocol_version);
-    let request = [];
+    let request = get_dummy_request_payload(request_id);
     let response = BinaryResponseAndRequest::new(val, &request);
     start_mock_binary_port(port, response.to_bytes().unwrap(), shutdown).await
 }
 
-pub async fn start_mock_binary_port(port: u16, data: Vec<u8>, shutdown: Arc<Notify>) -> JoinHandle<()> {
+pub async fn start_mock_binary_port(
+    port: u16,
+    data: Vec<u8>,
+    shutdown: Arc<Notify>,
+) -> JoinHandle<()> {
     let handler = tokio::spawn(async move {
         let binary_port = BinaryPortMock::new(port, data);
         binary_port.start(shutdown).await;
     });
     sleep(Duration::from_secs(3)).await; // This should be handled differently, preferably the mock binary port should inform that it already bound to the port
     handler
+}
+
+pub(crate) fn get_dummy_request() -> BinaryRequest {
+    BinaryRequest::Get(GetRequest::Information {
+        info_type_tag: 0,
+        key: vec![],
+    })
+}
+
+pub(crate) fn get_dummy_request_payload(request_id: Option<u64>) -> bytesrepr::Bytes {
+    let dummy_request = get_dummy_request();
+    encode_request(&dummy_request, request_id.unwrap_or_default())
+        .unwrap()
+        .into()
 }

--- a/sidecar/src/component.rs
+++ b/sidecar/src/component.rs
@@ -359,7 +359,8 @@ mod tests {
         let port = get_port();
         let shutdown = Arc::new(tokio::sync::Notify::new());
         let _mock_server_handle =
-            start_mock_binary_port_responding_with_stored_value(port, Arc::clone(&shutdown)).await;
+            start_mock_binary_port_responding_with_stored_value(port, None, Arc::clone(&shutdown))
+                .await;
         let component = RpcApiComponent::new();
         let mut config = all_components_all_enabled();
         config.rpc_server.as_mut().unwrap().node_client =

--- a/sidecar/src/component.rs
+++ b/sidecar/src/component.rs
@@ -358,9 +358,13 @@ mod tests {
     async fn given_rpc_api_server_component_when_config_should_return_some() {
         let port = get_port();
         let shutdown = Arc::new(tokio::sync::Notify::new());
-        let _mock_server_handle =
-            start_mock_binary_port_responding_with_stored_value(port, None, Arc::clone(&shutdown))
-                .await;
+        let _mock_server_handle = start_mock_binary_port_responding_with_stored_value(
+            port,
+            None,
+            None,
+            Arc::clone(&shutdown),
+        )
+        .await;
         let component = RpcApiComponent::new();
         let mut config = all_components_all_enabled();
         config.rpc_server.as_mut().unwrap().node_client =

--- a/types/src/legacy_sse_data/fixtures.rs
+++ b/types/src/legacy_sse_data/fixtures.rs
@@ -425,7 +425,7 @@ const RAW_TRANSACTION_ACCEPTED: &str = r#"
                 "scheduling": {
                     "FutureTimestamp": "2020-08-07T01:32:59.428Z"
                 },
-                "transaction_kind": 0
+                "transaction_category": 0
             },
             "approvals": [
                 {


### PR DESCRIPTION
This PR introduces the concept of "request id" to the binary port. This is used to dodge an edge case where it may happen that a response which has not been consumed is incorrectly served as a request to the next request.

The corresponding PR in casper-node is [here](https://github.com/casper-network/casper-node/pull/4726).

Fixes: https://github.com/casper-network/casper-sidecar/issues/312