### PR TITLE
Bump casper-node dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#44e67cdf1cb22e0f4dccd75199e3c337b1ddaa4e"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#74db75204bcb675fa5c399a81b18fa47f12a919b"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#44e67cdf1cb22e0f4dccd75199e3c337b1ddaa4e"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#74db75204bcb675fa5c399a81b18fa47f12a919b"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -166,12 +166,12 @@
               "name": "transaction",
               "value": {
                 "Version1": {
-                  "hash": "52a75f3651e450cc2c3ed534bf130bae2515950707d70bb60067aada30b97ca8",
+                  "hash": "f5582cb81a5abda63ebaa4edb3b05210ecbd63ffb8dd17bfbeb3b867f4014468",
                   "header": {
                     "chain_name": "casper-example",
                     "timestamp": "2020-11-17T00:39:24.072Z",
                     "ttl": "1h",
-                    "body_hash": "8c36f401d829378219b676ac6cceef90b08171499f5f5726ab5021df46d8b824",
+                    "body_hash": "aa24833ffbf31d62c8c8c4265349e7c09cd71952fcbce6f7b12daf5e340bf2cc",
                     "pricing_mode": {
                       "Fixed": {
                         "gas_price_tolerance": 5
@@ -222,12 +222,13 @@
                     ],
                     "target": "Native",
                     "entry_point": "Transfer",
+                    "transaction_kind": 0,
                     "scheduling": "Standard"
                   },
                   "approvals": [
                     {
                       "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "signature": "012eaaf83b1ed367ed424c859974bc5115a62d6b10d635f4b39d380414c4abcb2d54c01b7b96e0d27e00ed913f05f06d7bee9c25c31bbd8e9215961e61f835250d"
+                      "signature": "0137d3f468d8f8a6e63f4110d79be29b8c8428e9cd858a92049660e7851ae16a299640d1fc1c930ab6cb424f1a6eec0b194df74bede14f4af1b5133106f1280d0b"
                     }
                   ]
                 }
@@ -239,7 +240,7 @@
             "value": {
               "api_version": "2.0.0",
               "transaction_hash": {
-                "Version1": "52a75f3651e450cc2c3ed534bf130bae2515950707d70bb60067aada30b97ca8"
+                "Version1": "f5582cb81a5abda63ebaa4edb3b05210ecbd63ffb8dd17bfbeb3b867f4014468"
               }
             }
           }
@@ -369,7 +370,7 @@
                 ]
               },
               "execution_info": {
-                "block_hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884",
+                "block_hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42",
                 "block_height": 10,
                 "execution_result": {
                   "Version2": {
@@ -486,7 +487,7 @@
             {
               "name": "transaction_hash",
               "value": {
-                "Version1": "52a75f3651e450cc2c3ed534bf130bae2515950707d70bb60067aada30b97ca8"
+                "Version1": "f5582cb81a5abda63ebaa4edb3b05210ecbd63ffb8dd17bfbeb3b867f4014468"
               }
             },
             {
@@ -500,12 +501,12 @@
               "api_version": "2.0.0",
               "transaction": {
                 "Version1": {
-                  "hash": "52a75f3651e450cc2c3ed534bf130bae2515950707d70bb60067aada30b97ca8",
+                  "hash": "f5582cb81a5abda63ebaa4edb3b05210ecbd63ffb8dd17bfbeb3b867f4014468",
                   "header": {
                     "chain_name": "casper-example",
                     "timestamp": "2020-11-17T00:39:24.072Z",
                     "ttl": "1h",
-                    "body_hash": "8c36f401d829378219b676ac6cceef90b08171499f5f5726ab5021df46d8b824",
+                    "body_hash": "aa24833ffbf31d62c8c8c4265349e7c09cd71952fcbce6f7b12daf5e340bf2cc",
                     "pricing_mode": {
                       "Fixed": {
                         "gas_price_tolerance": 5
@@ -556,18 +557,19 @@
                     ],
                     "target": "Native",
                     "entry_point": "Transfer",
+                    "transaction_kind": 0,
                     "scheduling": "Standard"
                   },
                   "approvals": [
                     {
                       "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "signature": "012eaaf83b1ed367ed424c859974bc5115a62d6b10d635f4b39d380414c4abcb2d54c01b7b96e0d27e00ed913f05f06d7bee9c25c31bbd8e9215961e61f835250d"
+                      "signature": "0137d3f468d8f8a6e63f4110d79be29b8c8428e9cd858a92049660e7851ae16a299640d1fc1c930ab6cb424f1a6eec0b194df74bede14f4af1b5133106f1280d0b"
                     }
                   ]
                 }
               },
               "execution_info": {
-                "block_hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884",
+                "block_hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42",
                 "block_height": 10,
                 "execution_result": {
                   "Version2": {
@@ -1026,7 +1028,7 @@
             {
               "name": "state_identifier",
               "value": {
-                "BlockHash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884"
+                "BlockHash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42"
               }
             },
             {
@@ -1473,7 +1475,7 @@
               "chainspec_name": "casper-example",
               "starting_state_root_hash": "0000000000000000000000000000000000000000000000000000000000000000",
               "last_added_block_info": {
-                "hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884",
+                "hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42",
                 "timestamp": "2020-11-17T00:39:24.072Z",
                 "era_id": 1,
                 "height": 10,
@@ -1655,7 +1657,7 @@
             {
               "name": "block_identifier",
               "value": {
-                "Hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884"
+                "Hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42"
               }
             }
           ],
@@ -1666,11 +1668,11 @@
               "block_with_signatures": {
                 "block": {
                   "Version2": {
-                    "hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884",
+                    "hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42",
                     "header": {
                       "parent_hash": "0707070707070707070707070707070707070707070707070707070707070707",
                       "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
-                      "body_hash": "7929063af6c8431a679fd0fda108fa7e64e42a9e264df4ec8bb42ca877373631",
+                      "body_hash": "48859fb4865d8637d6a35cb224e222cd0e1b1c2dd72928932c1e35ac0550818b",
                       "random_bit": true,
                       "accumulated_seed": "ac979f51525cfd979b14aa7dc0737c5154eabe0db9280eceaa8dc8d2905b20d5",
                       "era_end": {
@@ -1709,22 +1711,22 @@
                       "transactions": {
                         "0": [
                           {
-                            "Version1": "1717171717171717171717171717171717171717171717171717171717171717"
+                            "Version1": "1414141414141414141414141414141414141414141414141414141414141414"
                           }
                         ],
                         "1": [
                           {
-                            "Version1": "1414141414141414141414141414141414141414141414141414141414141414"
+                            "Version1": "1515151515151515151515151515151515151515151515151515151515151515"
                           }
                         ],
                         "2": [
                           {
-                            "Version1": "1515151515151515151515151515151515151515151515151515151515151515"
+                            "Version1": "1616161616161616161616161616161616161616161616161616161616161616"
                           }
                         ],
                         "3": [
                           {
-                            "Version1": "1616161616161616161616161616161616161616161616161616161616161616"
+                            "Version1": "1717171717171717171717171717171717171717171717171717171717171717"
                           }
                         ]
                       },
@@ -1735,7 +1737,7 @@
                 "proofs": [
                   {
                     "public_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                    "signature": "01641f904df4c58b81b5fdae972186a9d709f1c03f3da4f5c4c9b80fbf98254056fc6048c64784c238811e4580bd46a10fe97be676cde5dd6a6d2be7dafedf7005"
+                    "signature": "01e18ca03d2ef0238a6a2460a222e0b818406bda99d4c05502c80232013559b926d1c8bca6bf65386f54a847d7850cb76c0c5fd5e633c34c749b8b9958a638d806"
                   }
                 ]
               }
@@ -2112,7 +2114,7 @@
             {
               "name": "block_identifier",
               "value": {
-                "Hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884"
+                "Hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42"
               }
             }
           ],
@@ -2121,7 +2123,7 @@
             "value": {
               "api_version": "2.0.0",
               "era_summary": {
-                "block_hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884",
+                "block_hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42",
                 "era_id": 42,
                 "stored_value": {
                   "EraInfo": {
@@ -2287,7 +2289,7 @@
             {
               "name": "block_identifier",
               "value": {
-                "Hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884"
+                "Hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42"
               }
             }
           ],
@@ -2296,7 +2298,7 @@
             "value": {
               "api_version": "2.0.0",
               "era_summary": {
-                "block_hash": "40fa940e609972313a6d598712fcb9cced789ed237bdac67aa1fe546e624c884",
+                "block_hash": "0744fcb72af43c5cc372039bc5a8bfee48808a9ce414acc0d6338a628c20eb42",
                 "era_id": 42,
                 "stored_value": {
                   "EraInfo": {
@@ -3252,7 +3254,8 @@
           "args",
           "entry_point",
           "scheduling",
-          "target"
+          "target",
+          "transaction_kind"
         ],
         "properties": {
           "args": {
@@ -3263,6 +3266,11 @@
           },
           "entry_point": {
             "$ref": "#/components/schemas/TransactionEntryPoint"
+          },
+          "transaction_kind": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
           },
           "scheduling": {
             "$ref": "#/components/schemas/TransactionScheduling"
@@ -7487,7 +7495,10 @@
             "description": "The rewards distributed to the validators.",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/U512"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/U512"
+              }
             }
           },
           "next_era_gas_price": {

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -174,12 +174,12 @@
               "name": "transaction",
               "value": {
                 "Version1": {
-                  "hash": "52a75f3651e450cc2c3ed534bf130bae2515950707d70bb60067aada30b97ca8",
+                  "hash": "f5582cb81a5abda63ebaa4edb3b05210ecbd63ffb8dd17bfbeb3b867f4014468",
                   "header": {
                     "chain_name": "casper-example",
                     "timestamp": "2020-11-17T00:39:24.072Z",
                     "ttl": "1h",
-                    "body_hash": "8c36f401d829378219b676ac6cceef90b08171499f5f5726ab5021df46d8b824",
+                    "body_hash": "aa24833ffbf31d62c8c8c4265349e7c09cd71952fcbce6f7b12daf5e340bf2cc",
                     "pricing_mode": {
                       "Fixed": {
                         "gas_price_tolerance": 5
@@ -230,12 +230,13 @@
                     ],
                     "target": "Native",
                     "entry_point": "Transfer",
+                    "transaction_kind": 0,
                     "scheduling": "Standard"
                   },
                   "approvals": [
                     {
                       "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                      "signature": "012eaaf83b1ed367ed424c859974bc5115a62d6b10d635f4b39d380414c4abcb2d54c01b7b96e0d27e00ed913f05f06d7bee9c25c31bbd8e9215961e61f835250d"
+                      "signature": "0137d3f468d8f8a6e63f4110d79be29b8c8428e9cd858a92049660e7851ae16a299640d1fc1c930ab6cb424f1a6eec0b194df74bede14f4af1b5133106f1280d0b"
                     }
                   ]
                 }
@@ -3822,7 +3823,8 @@
           "args",
           "entry_point",
           "scheduling",
-          "target"
+          "target",
+          "transaction_kind"
         ],
         "properties": {
           "args": {
@@ -3833,6 +3835,11 @@
           },
           "entry_point": {
             "$ref": "#/components/schemas/TransactionEntryPoint"
+          },
+          "transaction_kind": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
           },
           "scheduling": {
             "$ref": "#/components/schemas/TransactionScheduling"

--- a/types/src/legacy_sse_data/fixtures.rs
+++ b/types/src/legacy_sse_data/fixtures.rs
@@ -169,7 +169,7 @@ pub fn sample_transactions(
     let standard_deploy_hash = *deploy.hash();
     let standard_deploy = Transaction::Deploy(deploy);
 
-    let version_1 = TransactionV1::random_standard(rng, None, None);
+    let version_1 = TransactionV1::random(rng);
     let standard_version_1_hash = *version_1.hash();
     let standard_version_1 = Transaction::V1(version_1);
 
@@ -185,7 +185,7 @@ pub fn sample_transactions(
     let install_upgrade_v1_hash = *version_1.hash();
     let install_upgrade_v1 = Transaction::V1(version_1);
 
-    let version_1 = TransactionV1::random_staking(rng, Some(timestamp), Some(ttl));
+    let version_1 = TransactionV1::random_wasm(rng, Some(timestamp), Some(ttl));
     let auction_v1_hash = *version_1.hash();
     let auction_v1 = Transaction::V1(version_1);
 
@@ -272,7 +272,7 @@ pub fn era_end_v2() -> EraEndV2 {
     let mut rewards = BTreeMap::new();
     rewards.insert(
         parse_public_key("01235b932586ae5cc3135f7a0dc723185b87e5bd3ae0ac126a92c14468e976ff25"),
-        U512::from_dec_str("129457537").unwrap(),
+        vec![U512::from_dec_str("129457537").unwrap()],
     );
     EraEndV2::new(
         vec![
@@ -306,7 +306,7 @@ pub fn era_end_v2_with_reward_exceeding_u64() -> EraEndV2 {
     let mut rewards = BTreeMap::new();
     rewards.insert(
         parse_public_key("01235b932586ae5cc3135f7a0dc723185b87e5bd3ae0ac126a92c14468e976ff25"),
-        U512::from_dec_str("18446744073709551616").unwrap(),
+        vec![U512::from_dec_str("18446744073709551616").unwrap()],
     );
     EraEndV2::new(
         vec![

--- a/types/src/legacy_sse_data/fixtures.rs
+++ b/types/src/legacy_sse_data/fixtures.rs
@@ -424,7 +424,8 @@ const RAW_TRANSACTION_ACCEPTED: &str = r#"
                 "entry_point": "Transfer",
                 "scheduling": {
                     "FutureTimestamp": "2020-08-07T01:32:59.428Z"
-                }
+                },
+                "transaction_kind": 0
             },
             "approvals": [
                 {
@@ -754,10 +755,10 @@ const RAW_BLOCK_ADDED_V2: &str = r#"{
                             {"validator": "0102ffd4d2812d68c928712edd012fbcad54367bc6c5c254db22cf696772856566", "weight": "2"}
                         ],
                         "rewards": {
-                            "02028b18c949d849b377988ea5191b39340975db25f8b80f37cc829c9f79dbfb19fc": "749546792",
-                            "02028002c063228ff4e9d22d69154c499b86a4f7fdbf1d1e20f168b62da537af64c2": "788342677",
-                            "02038efa405f648c72f36b0e5f37db69ab213d44404591b24de21383d8cc161101ec": "86241635",
-                            "01f6bbd4a6fd10534290c58edb6090723d481cea444a8e8f70458e5136ea8c733c": "941794198"
+                            "02028b18c949d849b377988ea5191b39340975db25f8b80f37cc829c9f79dbfb19fc": ["749546792"],
+                            "02028002c063228ff4e9d22d69154c499b86a4f7fdbf1d1e20f168b62da537af64c2": ["788342677"],
+                            "02038efa405f648c72f36b0e5f37db69ab213d44404591b24de21383d8cc161101ec": ["86241635"],
+                            "01f6bbd4a6fd10534290c58edb6090723d481cea444a8e8f70458e5136ea8c733c": ["941794198"]
                         },
                         "next_era_gas_price": 1
                     },
@@ -769,10 +770,10 @@ const RAW_BLOCK_ADDED_V2: &str = r#"{
                 },
                 "body": {
                     "transactions": {
-                        "0": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e89"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e90"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e91"}],
-                        "1": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e80"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e81"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e82"}],
+                        "0": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e80"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e81"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e91"}],
+                        "1": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e80"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e90"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e82"}],
                         "2": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e83"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e84"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e85"}],
-                        "3": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e86"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e87"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e88"}]
+                        "3": [{"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e89"}, {"Deploy": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e90"}, {"Version1": "58aca0009fc41bd045d303db9e9f07416ff1fd8c76ecd98545eedf86f9459e88"}]
                     },
                     "rewarded_signatures": [[240],[0],[0]]
                 }

--- a/types/src/legacy_sse_data/translate_block_added.rs
+++ b/types/src/legacy_sse_data/translate_block_added.rs
@@ -31,13 +31,13 @@ impl EraEndV2Translator for DefaultEraEndV2Translator {
     fn translate(&self, era_end: &EraEndV2) -> Option<EraEndV1> {
         let mut rewards = BTreeMap::new();
         for (k, v) in era_end.rewards().iter() {
-            let max_u64 = U512::from(u64::MAX);
-            if v.gt(&max_u64) {
+            let amount = v.iter().cloned().sum::<U512>();
+            if amount > U512::from(u64::MAX) {
                 //We're not able to cast the reward to u64, so we skip this era end.
                 return None;
             }
-            println!("Reward: {:?} {:?} {:?}", k.clone(), v, v.as_u64());
-            rewards.insert(k.clone(), v.as_u64());
+            println!("Reward: {:?} {:?}", k.clone(), amount);
+            rewards.insert(k.clone(), amount.as_u64());
         }
         let era_report = EraReport::new(
             era_end.equivocators().to_vec(),

--- a/types/src/legacy_sse_data/translate_deploy_hashes.rs
+++ b/types/src/legacy_sse_data/translate_deploy_hashes.rs
@@ -15,9 +15,9 @@ pub struct TransferDeployHashesTranslator;
 impl DeployHashTranslator for StandardDeployHashesTranslator {
     fn translate(&self, block_body_v2: &casper_types::BlockBodyV2) -> Vec<DeployHash> {
         block_body_v2
-            .standard()
+            .all_transactions()
             .filter_map(|el| match el {
-                TransactionHash::Deploy(deploy_hash) => Some(deploy_hash),
+                &TransactionHash::Deploy(deploy_hash) => Some(deploy_hash),
                 TransactionHash::V1(_) => None,
             })
             .collect()

--- a/types/src/legacy_sse_data/translate_deploy_hashes.rs
+++ b/types/src/legacy_sse_data/translate_deploy_hashes.rs
@@ -15,9 +15,11 @@ pub struct TransferDeployHashesTranslator;
 impl DeployHashTranslator for StandardDeployHashesTranslator {
     fn translate(&self, block_body_v2: &casper_types::BlockBodyV2) -> Vec<DeployHash> {
         block_body_v2
-            .all_transactions()
+            .small()
+            .chain(block_body_v2.medium())
+            .chain(block_body_v2.large())
             .filter_map(|el| match el {
-                &TransactionHash::Deploy(deploy_hash) => Some(deploy_hash),
+                TransactionHash::Deploy(deploy_hash) => Some(deploy_hash),
                 TransactionHash::V1(_) => None,
             })
             .collect()


### PR DESCRIPTION
There were some changes in the node:
- addition of `transaction_kind`
- `rewards` changed from `BTreeMap<PublicKey, Vec<U512>>` to `BTreeMap<PublicKey, U512>`
- `standard` method in `BlockBodyV2` has been replaced by `large`, `medium` and `small`

Some of it causes parsing errors in the sidecar