### PR TITLE
Bump casper-node dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#74db75204bcb675fa5c399a81b18fa47f12a919b"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#f803ee53db31edd5f7f3c1fa1e0ec0ea59550158"
 dependencies = [
  "bincode",
  "bytes",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#74db75204bcb675fa5c399a81b18fa47f12a919b"
+source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#f803ee53db31edd5f7f3c1fa1e0ec0ea59550158"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/resources/test/rpc_schema.json
+++ b/resources/test/rpc_schema.json
@@ -3522,6 +3522,13 @@
         "description": "Entry point of a Transaction.",
         "oneOf": [
           {
+            "description": "The standard `call` entry point used in session code.",
+            "type": "string",
+            "enum": [
+              "Call"
+            ]
+          },
+          {
             "description": "A non-native, arbitrary entry point.",
             "type": "object",
             "required": [

--- a/resources/test/speculative_rpc_schema.json
+++ b/resources/test/speculative_rpc_schema.json
@@ -4072,6 +4072,13 @@
         "description": "Entry point of a Transaction.",
         "oneOf": [
           {
+            "description": "The standard `call` entry point used in session code.",
+            "type": "string",
+            "enum": [
+              "Call"
+            ]
+          },
+          {
             "description": "A non-native, arbitrary entry point.",
             "type": "object",
             "required": [


### PR DESCRIPTION
this update is needed to fix transactions:
```
response for rpc-id -3942237979070810244 account_put_transaction is json-rpc error: {"code":-32602,"message":"Invalid params","data":"Failed to parse 'params' field: unknown variant `Call`, expected one of `Custom`, `Transfer`, `AddBid`, `WithdrawBid`, `Delegate`, `Undelegate`, `Redelegate`, `ActivateBid`, `ChangeBidPublicKey`"}
```