### PR TITLE
Making SSE event storage optional. From now the [sse_server] config s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,53 +6,54 @@
 
 - [Summary of Purpose](#summary-of-purpose)
 - [System Components and Architecture](#system-components-and-architecture)
-   - [The SSE server](#the-sse-server)
-   - [The REST API server](#the-rest-api-server)
-	- [The Admin API server](#the-admin-api-server)
-	- [The RPC API server](#the-rpc-api-server)
+  - [The SSE server](#the-sse-server)
+  - [The REST API server](#the-rest-api-server)
+  - [The Admin API server](#the-admin-api-server)
+  - [The RPC API server](#the-rpc-api-server)
 - [Configuring the Sidecar](#configuring-the-sidecar)
-	- [RPC server setup](#rpc-server-setup)
-	- [SSE server setup](#sse-server-setup)
-		- [Configuring SSE node connections](#configuring-sse-node-connections)
-		- [Configuring SSE legacy emulations](#configuring-sse-legacy-emulations)
-		- [Configuring the event stream](#configuring-the-event-stream)
-	- [REST server setup](#rest-server-setup)
-	- [Storage setup](#setup-storage)
-	- [Database connectivity setup](#database-connectivity-setup)
-		- [SQLite database](#sqlite-database)
-		- [PostgreSQL database](#postgresql-database)
-	- [Admin server setup](#admin-server-setup)
+  - [RPC server setup](#rpc-server-setup)
+  - [SSE server setup](#sse-server-setup)
+    - [Configuring SSE node connections](#configuring-sse-node-connections)
+    - [Configuring SSE legacy emulations](#configuring-sse-legacy-emulations)
+    - [Configuring the event stream](#configuring-the-event-stream)
+  - [REST server setup](#rest-server-setup)
+  - [Storage setup](#setup-storage)
+  - [Database connectivity setup](#database-connectivity-setup)
+    - [SQLite database](#sqlite-database)
+    - [PostgreSQL database](#postgresql-database)
+  - [Admin server setup](#admin-server-setup)
 - [Running and Testing the Sidecar](#running-and-testing-the-sidecar)
-	- [Prerequisites](#prerequisites)
-   - [Running the Sidecar](#running-the-sidecar)
-   - [Testing the Sidecar](#testing-the-sidecar)
+  - [Prerequisites](#prerequisites)
+  - [Running the Sidecar](#running-the-sidecar)
+  - [Testing the Sidecar](#testing-the-sidecar)
 - [Swagger Documentation](#swagger-documentation)
 - [OpenAPI Specification](#openapi-specification)
 - [Troubleshooting Tips](#troubleshooting-tips)
-	- [Checking liveness](#checking-liveness)
-	- [Checking the node connection](#checking-the-node-connection)
-	- [Diagnosing errors](#diagnosing-errors)
-	- [Monitoring memory consumption](#monitoring-memory-consumption)
-	- [Ensuring sufficient storage](#ensuring-sufficient-storage)
-	- [Inspecting the REST API](#inspecting-the-rest-api)
-	- [Limiting concurrent requests](#limiting-concurrent-requests)
+  - [Checking liveness](#checking-liveness)
+  - [Checking the node connection](#checking-the-node-connection)
+  - [Diagnosing errors](#diagnosing-errors)
+  - [Monitoring memory consumption](#monitoring-memory-consumption)
+  - [Ensuring sufficient storage](#ensuring-sufficient-storage)
+  - [Inspecting the REST API](#inspecting-the-rest-api)
+  - [Limiting concurrent requests](#limiting-concurrent-requests)
 
 ## Summary of Purpose
 
 The Casper Sidecar is an application running in tandem with the node process. It allows subscribers to monitor a node's event stream, query stored events, and query the node's JSON RPC API, thus receiving faster responses and reducing the load placed on the node. Its primary purpose is to:
 
-* Offload the node from broadcasting SSE events to multiple clients.
-* Provide client features that aren't part of the nodes' functionality, nor should they be.
+- Offload the node from broadcasting SSE events to multiple clients.
+- Provide client features that aren't part of the nodes' functionality, nor should they be.
 
 While the primary use case for the Sidecar application is running alongside the node on the same machine, it can be run remotely if necessary.
 
 ## System Components and Architecture
 
 The Casper Sidecar provides the following functionalities:
-* A server-sent events (SSE) server with an `/events` endpoint that streams all the events received from all connected nodes. The Sidecar also stores these events.
-* A REST API server that allows clients to query stored events.
-* A JSON RPC bridge between end users and a Casper node's binary port.
-* Legacy emulation for clients using older versions of the SSE API.
+
+- A server-sent events (SSE) server with an `/events` endpoint that streams all the events received from all connected nodes. The Sidecar also stores these events.
+- A REST API server that allows clients to query stored events.
+- A JSON RPC bridge between end users and a Casper node's binary port.
+- Legacy emulation for clients using older versions of the SSE API.
 
 The Sidecar has the following components and external dependencies:
 
@@ -101,13 +102,14 @@ The SSE Server has these components:
         SSE_SERVER_API --> RING_BUFFER
         SSE_LISTENER --3--> RING_BUFFER
         subgraph "connection"
-          SSE_LISTENER["SSE listener"]   
+          SSE_LISTENER["SSE listener"]
         end
      end
    end
 ```
 
 The SSE Listener processes events in this order:
+
 1. Fetch an event from the node's SSE port.
 2. Store the event.
 3. Publish the event to the SSE API.
@@ -115,9 +117,10 @@ The SSE Listener processes events in this order:
 Casper nodes offer an event stream API that returns server-sent events (SSEs) with JSON-encoded data. The Sidecar reads the event stream of all connected nodes, acting as a passthrough and replicating the SSE interface of the connected nodes.
 
 The Sidecar can:
-* Republish the current events from the node to clients listening to Sidecar's SSE API.
-* Publish a configurable number of previous events to clients connecting to the Sidecar's SSE API with `?start_from=` query (similar to the node's SSE API).
-* Store the events in external storage for clients to query them via the Sidecar's REST API.
+
+- Republish the current events from the node to clients listening to Sidecar's SSE API.
+- Publish a configurable number of previous events to clients connecting to the Sidecar's SSE API with `?start_from=` query (similar to the node's SSE API).
+- Store the events in external storage for clients to query them via the Sidecar's REST API.
 
 Enabling and configuring the SSE Server of the Sidecar is optional.
 
@@ -223,29 +226,29 @@ coefficient = 2
 max_attempts = 30
 ```
 
-* `main_server.enable_server` - The RPC API server will be enabled if set to true.
-* `main_server.address` - Address under which the main RPC API server will be available.
-* `main_server.qps_limit` - The maximum number of requests per second.
-* `main_server.max_body_bytes` - Maximum body size of request to API in bytes.
-* `main_server.cors_origin` - Configures the CORS origin.
+- `main_server.enable_server` - The RPC API server will be enabled if set to true.
+- `main_server.address` - Address under which the main RPC API server will be available.
+- `main_server.qps_limit` - The maximum number of requests per second.
+- `main_server.max_body_bytes` - Maximum body size of request to API in bytes.
+- `main_server.cors_origin` - Configures the CORS origin.
 
-* `speculative_exec_server.enable_server` - If set to true, the speculative RPC API server will be enabled.
-* `speculative_exec_server.address` - Address under which the speculative RPC API server will be available.
-* `speculative_exec_server.qps_limit` - The maximum number of requests per second.
-* `speculative_exec_server.max_body_bytes` - Maximum body size of request to API in bytes.
-* `speculative_exec_server.cors_origin` - Configures the CORS origin.
+- `speculative_exec_server.enable_server` - If set to true, the speculative RPC API server will be enabled.
+- `speculative_exec_server.address` - Address under which the speculative RPC API server will be available.
+- `speculative_exec_server.qps_limit` - The maximum number of requests per second.
+- `speculative_exec_server.max_body_bytes` - Maximum body size of request to API in bytes.
+- `speculative_exec_server.cors_origin` - Configures the CORS origin.
 
-* `node_client.address` - Address of the Casper Node binary port.
-* `node_client.max_message_size_bytes` - Maximum binary port message size in bytes.
-* `node_client.request_limit` - Maximum number of in-flight requests.
-* `node_client.request_buffer_size` - Number of node requests that can be buffered.
-* `node_client.message_timeout_secs` - Timeout for the message.
-* `node_client.client_access_timeout_secs` - Timeout for the client connection.
+- `node_client.address` - Address of the Casper Node binary port.
+- `node_client.max_message_size_bytes` - Maximum binary port message size in bytes.
+- `node_client.request_limit` - Maximum number of in-flight requests.
+- `node_client.request_buffer_size` - Number of node requests that can be buffered.
+- `node_client.message_timeout_secs` - Timeout for the message.
+- `node_client.client_access_timeout_secs` - Timeout for the client connection.
 
-* `node_client.exponential_backoff.initial_delay_ms` - Timeout after the first broken connection (backoff) in milliseconds.
-* `node_client.exponential_backoff.max_delay_ms` - Maximum timeout after a broken connection in milliseconds.
-* `node_client.exponential_backoff.coefficient` - Coefficient for the exponential backoff. The next timeout is calculated as min(`current_timeout * coefficient`, `max_delay_ms`).
-* `node_client.exponential_backoff.max_attempts` - Maximum number of times to try to reconnect to the binary port of the node.
+- `node_client.exponential_backoff.initial_delay_ms` - Timeout after the first broken connection (backoff) in milliseconds.
+- `node_client.exponential_backoff.max_delay_ms` - Maximum timeout after a broken connection in milliseconds.
+- `node_client.exponential_backoff.coefficient` - Coefficient for the exponential backoff. The next timeout is calculated as min(`current_timeout * coefficient`, `max_delay_ms`).
+- `node_client.exponential_backoff.max_attempts` - Maximum number of times to try to reconnect to the binary port of the node.
 
 ### SSE server setup
 
@@ -255,6 +258,7 @@ The Sidecar SSE server is used to connect to Casper nodes, listen to events from
 [sse_server]
 enable_server = true
 emulate_legacy_sse_apis = ["V1"]
+disable_event_persistence = false
 
 [[sse_server.connections]]
  <Described later in the document>
@@ -263,8 +267,9 @@ emulate_legacy_sse_apis = ["V1"]
  <Described later in the document>
 ```
 
-* `sse_server.enable_server` - If set to true, the SSE server will be enabled.
-* `sse_server.emulate_legacy_sse_apis` - A list of legacy Casper node SSE APIs to emulate. The Sidecar will expose SSE endpoints that are compatible with specified versions. Please bear in mind that this feature is an emulation and should be used only for transition periods. In most scenarios, having a 1-to-1 mapping of new messages into old formats is impossible, so this can be a process that loses some data and/or doesn't emit all messages that come from the Casper node. See the [Legacy SSE Emulation](./LEGACY_SSE_EMULATION.md) page for more details.
+- `sse_server.enable_server` - If set to true, the SSE server will be enabled.
+- `sse_server.emulate_legacy_sse_apis` - A list of legacy Casper node SSE APIs to emulate. The Sidecar will expose SSE endpoints that are compatible with specified versions. Please bear in mind that this feature is an emulation and should be used only for transition periods. In most scenarios, having a 1-to-1 mapping of new messages into old formats is impossible, so this can be a process that loses some data and/or doesn't emit all messages that come from the Casper node. See the [Legacy SSE Emulation](./LEGACY_SSE_EMULATION.md) page for more details.
+- `sse_server.disable_event_persistence` - If set to true, SSE server will not send events to storage. This is useful if you want to use sidecar only as a pass-through for sse events. The property is optional, if not defined it will behave as false.
 
 #### Configuring SSE node connections
 
@@ -275,6 +280,7 @@ The `node_connections` option configures the node (or multiple nodes) to which t
 ```toml
 [sse_server]
 enable_server = true
+disable_event_persistence = false
 
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
@@ -313,16 +319,16 @@ no_message_timeout_in_seconds = 60
 sleep_between_keep_alive_checks_in_seconds = 30
 ```
 
-* `ip_address` - The IP address of the node to monitor.
-* `sse_port` - The node's event stream (SSE) port. This [example configuration](./resources/example_configs/EXAMPLE_NODE_CONFIG.toml) uses port `9999`.
-* `rest_port` - The node's REST endpoint for status and metrics. This [example configuration](./resources/example_configs/EXAMPLE_NODE_CONFIG.toml) uses port `8888`.
-* `max_attempts` - The maximum number of attempts the Sidecar will make to connect to the node. If set to `0`, the Sidecar will not attempt to connect.
-* `delay_between_retries_in_seconds` - The delay between attempts to connect to the node.
-* `allow_partial_connection` - Determining whether the Sidecar will allow a partial connection to this node.
-* `enable_logging` - This enables the logging of events from the node in question.
-* `connection_timeout_in_seconds` - Number of seconds before the connection request times out. This parameter is optional, and defaults to 5.
-* `no_message_timeout_in_seconds` - Number of seconds after which the connection will be restarted if no bytes were received. This parameter is optional, and defaults to 120.
-* `sleep_between_keep_alive_checks_in_seconds` - Optional parameter specifying the time intervals (in seconds) for checking if the connection is still alive. Defaults to 60.
+- `ip_address` - The IP address of the node to monitor.
+- `sse_port` - The node's event stream (SSE) port. This [example configuration](./resources/example_configs/EXAMPLE_NODE_CONFIG.toml) uses port `9999`.
+- `rest_port` - The node's REST endpoint for status and metrics. This [example configuration](./resources/example_configs/EXAMPLE_NODE_CONFIG.toml) uses port `8888`.
+- `max_attempts` - The maximum number of attempts the Sidecar will make to connect to the node. If set to `0`, the Sidecar will not attempt to connect.
+- `delay_between_retries_in_seconds` - The delay between attempts to connect to the node.
+- `allow_partial_connection` - Determining whether the Sidecar will allow a partial connection to this node.
+- `enable_logging` - This enables the logging of events from the node in question.
+- `connection_timeout_in_seconds` - Number of seconds before the connection request times out. This parameter is optional, and defaults to 5.
+- `no_message_timeout_in_seconds` - Number of seconds after which the connection will be restarted if no bytes were received. This parameter is optional, and defaults to 120.
+- `sleep_between_keep_alive_checks_in_seconds` - Optional parameter specifying the time intervals (in seconds) for checking if the connection is still alive. Defaults to 60.
 
 #### Configuring SSE legacy emulations
 
@@ -332,12 +338,14 @@ Applications using version 1 of a Casper node's event stream server can still fu
 [sse_server]
 enable_server = true
 emulate_legacy_sse_apis = ["V1"]
+disable_event_persistence = false
 ```
 
 This setting will expose three legacy SSE endpoints with the following events streamed on each endpoint:
-* `/events/sigs` - Finality Signature events
-* `/events/deploys` - DeployAccepted events
-* `/events/main` - All other legacy events, including BlockAdded, DeployProcessed, DeployExpired, Fault, Step, and Shutdown events
+
+- `/events/sigs` - Finality Signature events
+- `/events/deploys` - DeployAccepted events
+- `/events/main` - All other legacy events, including BlockAdded, DeployProcessed, DeployExpired, Fault, Step, and Shutdown events
 
 See the [Legacy SSE Emulation](./LEGACY_SSE_EMULATION.md) page for more details.
 
@@ -352,9 +360,9 @@ max_concurrent_subscribers = 100
 event_stream_buffer_length = 5000
 ```
 
-* `event_stream_server.port` - The port under which the Sidecar's SSE server publishes events.
-* `event_stream_server.max_concurrent_subscribers` - The maximum number of subscribers that can monitor the Sidecar's event stream.
-* `event_stream_server.event_stream_buffer_length` - The number of events that the stream will hold in its buffer for reference when a subscriber reconnects.
+- `event_stream_server.port` - The port under which the Sidecar's SSE server publishes events.
+- `event_stream_server.max_concurrent_subscribers` - The maximum number of subscribers that can monitor the Sidecar's event stream.
+- `event_stream_server.event_stream_buffer_length` - The number of events that the stream will hold in its buffer for reference when a subscriber reconnects.
 
 ### REST server setup
 
@@ -369,11 +377,11 @@ max_requests_per_second = 50
 request_timeout_in_seconds = 10
 ```
 
-* `enable_server` - If set to true, the RPC API server will be enabled.
-* `port` - The port for accessing the Sidecar's REST server. `18888` is the default, but operators are free to choose their own port as needed.
-* `max_concurrent_requests` - The maximum total number of simultaneous requests that can be made to the REST server.
-* `max_requests_per_second` - The maximum total number of requests that can be made per second.
-* `request_timeout_in_seconds` - The total time before a request times out.
+- `enable_server` - If set to true, the RPC API server will be enabled.
+- `port` - The port for accessing the Sidecar's REST server. `18888` is the default, but operators are free to choose their own port as needed.
+- `max_concurrent_requests` - The maximum total number of simultaneous requests that can be made to the REST server.
+- `max_requests_per_second` - The maximum total number of requests that can be made per second.
+- `request_timeout_in_seconds` - The total time before a request times out.
 
 ### Storage setup
 
@@ -381,7 +389,7 @@ This directory stores the SSE cache and an SQLite database if the Sidecar was co
 
 ```toml
 [storage]
-storage_path = "./target/storage"
+storage_folder = "./target/storage"
 ```
 
 ### Database connectivity setup
@@ -399,21 +407,20 @@ max_connections_in_pool = 100
 wal_autocheckpointing_interval = 1000
 ```
 
-* `storage.sqlite_config.file_name` - The database file path.
-* `storage.sqlite_config.max_connections_in_pool` - The maximum number of connections to the database (should generally be left as is).
-* `storage.sqlite_config.wal_autocheckpointing_interval` - This controls how often the system commits pages to the database. The value determines the maximum number of pages before forcing a commit. More information can be found [here](https://www.sqlite.org/compile.html#default_wal_autocheckpoint).
+- `storage.sqlite_config.file_name` - The database file name. The base folder where this file will be stored comes from `storage.storage_folder`.
+- `storage.sqlite_config.max_connections_in_pool` - The maximum number of connections to the database (should generally be left as is).
+- `storage.sqlite_config.wal_autocheckpointing_interval` - This controls how often the system commits pages to the database. The value determines the maximum number of pages before forcing a commit. More information can be found [here](https://www.sqlite.org/compile.html#default_wal_autocheckpoint).
 
 #### PostgreSQL database
 
 The properties listed below are elements of the PostgreSQL database connection that can be configured for the Sidecar.
 
-* `storage.postgresql_config.database_name` - Name of the database.
-* `storage.postgresql_config.host` - URL to PostgreSQL instance.
-* `storage.postgresql_config.database_username` - Username.
-* `storage.postgresql_config.database_password` - Database password.
-* `storage.postgresql_config.max_connections_in_pool` - The maximum number of connections to the database.
-* `storage.postgresql_config.port` - The port for the database connection.
-
+- `storage.postgresql_config.database_name` - Name of the database.
+- `storage.postgresql_config.host` - URL to PostgreSQL instance.
+- `storage.postgresql_config.database_username` - Username.
+- `storage.postgresql_config.database_password` - Database password.
+- `storage.postgresql_config.max_connections_in_pool` - The maximum number of connections to the database.
+- `storage.postgresql_config.port` - The port for the database connection.
 
 To run the Sidecar with PostgreSQL, you can set the following database environment variables to control how the Sidecar connects to the database. This is the suggested method to set the connection information for the PostgreSQL database.
 
@@ -466,10 +473,10 @@ max_concurrent_requests = 1
 max_requests_per_second = 1
 ```
 
-* `enable_server` - If set to true, the RPC API server will be enabled.
-* `port` - The port for accessing the Sidecar's admin server.
-* `max_concurrent_requests` - The maximum total number of simultaneous requests that can be sent to the admin server.
-* `max_requests_per_second` - The maximum total number of requests that can be sent per second to the admin server.
+- `enable_server` - If set to true, the RPC API server will be enabled.
+- `port` - The port for accessing the Sidecar's admin server.
+- `max_concurrent_requests` - The maximum total number of simultaneous requests that can be sent to the admin server.
+- `max_requests_per_second` - The maximum total number of requests that can be sent per second to the admin server.
 
 Access the admin server at `http://localhost:18887/metrics/`.
 
@@ -479,11 +486,11 @@ Access the admin server at `http://localhost:18887/metrics/`.
 
 To compile, test, and run the Sidecar, install the following software first:
 
-* CMake 3.1.4 or greater
-* [Rust](https://www.rust-lang.org/tools/install)
-* pkg-config
-* gcc
-* g++
+- CMake 3.1.4 or greater
+- [Rust](https://www.rust-lang.org/tools/install)
+- pkg-config
+- gcc
+- g++
 
 ### Running the Sidecar
 
@@ -503,11 +510,11 @@ RUST_LOG=info cargo run -p casper-sidecar -- --path-to-config ./resources/exampl
 
 The log levels, listed in order of increasing verbosity, are:
 
-* `ERROR`
-* `WARN`
-* `INFO`
-* `DEBUG`
-* `TRACE`
+- `ERROR`
+- `WARN`
+- `INFO`
+- `DEBUG`
+- `TRACE`
 
 Further details about log levels can be found [here](https://docs.rs/env_logger/0.9.1/env_logger/#enabling-logging).
 
@@ -585,9 +592,7 @@ In the above `node_statuses`, you can see which nodes are connecting, which are 
 - `-1` - The Sidecar is not connected and has reached the maximum connection attempts
 - `-2` - The Sidecar is not connected due to an incompatible node version
 
-
 ### Diagnosing errors
-
 
 To diagnose errors, look for `error` logs and check the `error_counts` on the metrics page, `http://SIDECAR_URL:SIDECAR_ADMIN_PORT/metrics`, where most of the errors related to data flow will be stored:
 

--- a/event_sidecar/src/database/sqlite_database.rs
+++ b/event_sidecar/src/database/sqlite_database.rs
@@ -99,14 +99,11 @@ impl SqliteDatabase {
 #[cfg(any(feature = "testing", test))]
 impl SqliteDatabase {
     pub async fn new_from_config(storage_config: &StorageConfig) -> Result<SqliteDatabase, Error> {
-        match storage_config {
-            StorageConfig::SqliteDbConfig {
-                storage_path,
-                sqlite_config,
-            } => SqliteDatabase::new(Path::new(storage_path), sqlite_config.clone()).await,
-            StorageConfig::PostgreSqlDbConfig { .. } => Err(Error::msg(
-                "can't build Sqlite database from postgres config",
-            )),
+        if let Some(sqlite_config) = &storage_config.sqlite_config {
+            let storage_folder = Path::new(&storage_config.storage_folder);
+            SqliteDatabase::new(storage_folder, sqlite_config.clone()).await
+        } else {
+            Err(Error::msg("No sqlite config found"))
         }
     }
 

--- a/event_sidecar/src/event_handling_service.rs
+++ b/event_sidecar/src/event_handling_service.rs
@@ -1,0 +1,105 @@
+use crate::{
+    types::database::DatabaseWriteError, FinalitySignature, Step, TransactionAccepted,
+    TransactionProcessed,
+};
+use async_trait::async_trait;
+use casper_event_listener::SseEvent;
+use casper_event_types::{sse_data::SseData, Filter};
+use casper_types::{
+    Block, BlockHash, EraId, ProtocolVersion, PublicKey, Timestamp, TransactionHash,
+};
+use metrics::observe_error;
+use tokio::sync::mpsc::Sender;
+use tracing::{debug, trace, warn};
+pub mod db_saving_event_handling_service;
+pub mod no_db_event_handling_service;
+pub use {
+    db_saving_event_handling_service::DbSavingEventHandlingService,
+    no_db_event_handling_service::NoDbEventHandlingService,
+};
+
+#[async_trait]
+pub trait EventHandlingService {
+    async fn handle_api_version(&self, version: ProtocolVersion, filter: Filter);
+
+    async fn handle_block_added(
+        &self,
+        block_hash: BlockHash,
+        block: Box<Block>,
+        sse_event: SseEvent,
+    );
+
+    async fn handle_transaction_accepted(
+        &self,
+        transaction_accepted: TransactionAccepted,
+        sse_event: SseEvent,
+    );
+
+    async fn handle_transaction_expired(
+        &self,
+        transaction_hash: TransactionHash,
+        sse_event: SseEvent,
+    );
+
+    async fn handle_transaction_processed(
+        &self,
+        transaction_processed: TransactionProcessed,
+        sse_event: SseEvent,
+    );
+
+    async fn handle_fault(
+        &self,
+        era_id: EraId,
+        timestamp: Timestamp,
+        public_key: PublicKey,
+        sse_event: SseEvent,
+    );
+
+    async fn handle_step(&self, step: Step, sse_event: SseEvent);
+
+    async fn handle_finality_signature(
+        &self,
+        finality_signature: FinalitySignature,
+        sse_event: SseEvent,
+    );
+
+    async fn handle_shutdown(&self, sse_event: SseEvent);
+}
+
+async fn handle_database_save_result<T>(
+    entity_name: &str,
+    entity_identifier: &str,
+    res: Result<T, DatabaseWriteError>,
+    outbound_sse_data_sender: &Sender<(SseData, Option<Filter>)>,
+    inbound_filter: Filter,
+    sse_data: SseData,
+) {
+    match res {
+        Ok(_) => {
+            if let Err(error) = outbound_sse_data_sender
+                .send((sse_data, Some(inbound_filter)))
+                .await
+            {
+                debug!(
+                    "Error when sending to outbound_sse_data_sender. Error: {}",
+                    error
+                );
+            }
+        }
+        Err(DatabaseWriteError::UniqueConstraint(uc_err)) => {
+            debug!(
+                "Already received {} ({}), logged in event_log",
+                entity_name, entity_identifier,
+            );
+            trace!(?uc_err);
+        }
+        Err(other_err) => {
+            count_error(format!("db_save_error_{}", entity_name).as_str());
+            warn!(?other_err, "Unexpected error saving {}", entity_identifier);
+        }
+    }
+}
+
+fn count_error(reason: &str) {
+    observe_error("event_handling", reason);
+}

--- a/event_sidecar/src/event_handling_service/db_saving_event_handling_service.rs
+++ b/event_sidecar/src/event_handling_service/db_saving_event_handling_service.rs
@@ -1,0 +1,326 @@
+use crate::{
+    event_handling_service::count_error,
+    transaction_hash_to_identifier,
+    types::database::{DatabaseReader, DatabaseWriteError, DatabaseWriter},
+    BlockAdded, Fault, FinalitySignature, Step, TransactionAccepted, TransactionExpired,
+    TransactionProcessed,
+};
+use async_trait::async_trait;
+use casper_event_listener::SseEvent;
+use casper_event_types::{sse_data::SseData, Filter};
+use casper_types::{
+    Block, BlockHash, EraId, ProtocolVersion, PublicKey, Timestamp, TransactionHash,
+};
+use derive_new::new;
+use hex_fmt::HexFmt;
+use metrics::sse::observe_contract_messages;
+use tokio::sync::mpsc::Sender;
+use tracing::{debug, info, warn};
+
+use super::{handle_database_save_result, EventHandlingService};
+
+#[derive(new, Clone)]
+pub struct DbSavingEventHandlingService<Db: DatabaseReader + DatabaseWriter + Clone + Send + Sync> {
+    outbound_sse_data_sender: Sender<(SseData, Option<Filter>)>,
+    database: Db,
+    enable_event_logging: bool,
+}
+
+#[async_trait]
+impl<Db> EventHandlingService for DbSavingEventHandlingService<Db>
+where
+    Db: DatabaseReader + DatabaseWriter + Clone + Send + Sync + 'static,
+{
+    async fn handle_api_version(&self, version: ProtocolVersion, filter: Filter) {
+        if let Err(error) = self
+            .outbound_sse_data_sender
+            .send((SseData::ApiVersion(version), Some(filter)))
+            .await
+        {
+            debug!(
+                "Error when sending to outbound_sse_data_sender. Error: {}",
+                error
+            );
+        }
+        if self.enable_event_logging {
+            info!(%version, "API Version");
+        }
+    }
+
+    async fn handle_block_added(
+        &self,
+        block_hash: BlockHash,
+        block: Box<Block>,
+        sse_event: SseEvent,
+    ) {
+        if self.enable_event_logging {
+            let hex_block_hash = HexFmt(block_hash.inner());
+            info!("Block Added: {:18}", hex_block_hash);
+            debug!("Block Added: {}", hex_block_hash);
+        }
+        let id = sse_event.id;
+        let source = sse_event.source.to_string();
+        let api_version = sse_event.api_version;
+        let network_name = sse_event.network_name;
+        let filter = sse_event.inbound_filter;
+        let res = self
+            .database
+            .save_block_added(
+                BlockAdded::new(block_hash, block), //TODO maybe we could avoid these clones
+                id,
+                source,
+                api_version,
+                network_name,
+            )
+            .await;
+        handle_database_save_result(
+            "BlockAdded",
+            HexFmt(block_hash.inner()).to_string().as_str(),
+            res,
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_transaction_accepted(
+        &self,
+        transaction_accepted: TransactionAccepted,
+        sse_event: SseEvent,
+    ) {
+        let entity_identifier = transaction_accepted.identifier();
+        if self.enable_event_logging {
+            info!("Transaction Accepted: {:18}", entity_identifier);
+            debug!("Transaction Accepted: {}", entity_identifier);
+        }
+        let id = sse_event.id;
+        let source = sse_event.source.to_string();
+        let api_version = sse_event.api_version;
+        let network_name = sse_event.network_name;
+        let filter = sse_event.inbound_filter;
+        let res = self
+            .database
+            .save_transaction_accepted(transaction_accepted, id, source, api_version, network_name)
+            .await;
+        handle_database_save_result(
+            "TransactionAccepted",
+            &entity_identifier,
+            res,
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_transaction_expired(
+        &self,
+        transaction_hash: TransactionHash,
+        sse_event: SseEvent,
+    ) {
+        let entity_identifier = transaction_hash_to_identifier(&transaction_hash);
+        if self.enable_event_logging {
+            info!("Transaction Expired: {:18}", entity_identifier);
+            debug!("Transaction Expired: {}", entity_identifier);
+        }
+        let id = sse_event.id;
+        let source = sse_event.source.to_string();
+        let api_version = sse_event.api_version;
+        let network_name = sse_event.network_name;
+        let filter = sse_event.inbound_filter;
+        let res = self
+            .database
+            .save_transaction_expired(
+                TransactionExpired::new(transaction_hash),
+                id,
+                source.to_string(),
+                api_version,
+                network_name,
+            )
+            .await;
+        handle_database_save_result(
+            "TransactionExpired",
+            &entity_identifier,
+            res,
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_transaction_processed(
+        &self,
+        transaction_processed: TransactionProcessed,
+        sse_event: SseEvent,
+    ) {
+        let entity_identifier = transaction_processed.identifier();
+        if self.enable_event_logging {
+            info!("Transaction Processed: {:18}", entity_identifier);
+            debug!("Transaction Processed: {}", entity_identifier);
+        }
+        let id = sse_event.id;
+        let source = sse_event.source.to_string();
+        let api_version = sse_event.api_version;
+        let network_name = sse_event.network_name;
+        let filter = sse_event.inbound_filter;
+        let messages_len = transaction_processed.messages().len();
+
+        if messages_len > 0 {
+            observe_contract_messages("all", messages_len);
+        }
+        let res = self
+            .database
+            .save_transaction_processed(
+                transaction_processed,
+                id,
+                source.to_string(),
+                api_version,
+                network_name,
+            )
+            .await;
+        if res.is_ok() && messages_len > 0 {
+            observe_contract_messages("unique", messages_len);
+        }
+        handle_database_save_result(
+            "TransactionProcessed",
+            &entity_identifier,
+            res,
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_fault(
+        &self,
+        era_id: EraId,
+        timestamp: Timestamp,
+        public_key: PublicKey,
+        sse_event: SseEvent,
+    ) {
+        let id = sse_event.id;
+        let source = sse_event.source.to_string();
+        let api_version = sse_event.api_version;
+        let network_name = sse_event.network_name;
+        let filter = sse_event.inbound_filter;
+        let fault_identifier = format!("{}-{}", era_id.value(), public_key);
+        let fault = Fault::new(era_id, public_key, timestamp);
+        warn!(%fault, "Fault reported");
+        let res = self
+            .database
+            .save_fault(fault, id, source, api_version, network_name)
+            .await;
+
+        handle_database_save_result(
+            "Fault",
+            &fault_identifier,
+            res,
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_step(&self, step: Step, sse_event: SseEvent) {
+        let era_id = step.era_id;
+        let step_identifier = format!("{}", era_id.value());
+        if self.enable_event_logging {
+            info!("Step at era: {}", step_identifier);
+        }
+
+        let id = sse_event.id;
+        let source = sse_event.source.to_string();
+        let api_version = sse_event.api_version;
+        let network_name = sse_event.network_name;
+        let filter = sse_event.inbound_filter;
+        let res = self
+            .database
+            .save_step(step, id, source, api_version, network_name)
+            .await;
+        handle_database_save_result(
+            "Step",
+            step_identifier.as_str(),
+            res,
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_finality_signature(
+        &self,
+        finality_signature: FinalitySignature,
+        sse_event: SseEvent,
+    ) {
+        if self.enable_event_logging {
+            debug!(
+                "Finality Signature: {} for {}",
+                finality_signature.signature(),
+                finality_signature.block_hash()
+            );
+        }
+        let id = sse_event.id;
+        let source = sse_event.source.to_string();
+        let api_version = sse_event.api_version;
+        let network_name = sse_event.network_name;
+        let filter = sse_event.inbound_filter;
+        let res = self
+            .database
+            .save_finality_signature(
+                finality_signature.clone(),
+                id,
+                source,
+                api_version,
+                network_name,
+            )
+            .await;
+        handle_database_save_result(
+            "FinalitySignature",
+            "",
+            res,
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_shutdown(&self, sse_event: SseEvent) {
+        warn!("Node ({}) is unavailable", sse_event.source.to_string());
+        let res = self
+            .database
+            .save_shutdown(
+                sse_event.id,
+                sse_event.source.to_string(),
+                sse_event.api_version,
+                sse_event.network_name,
+            )
+            .await;
+        match res {
+            Ok(_) | Err(DatabaseWriteError::UniqueConstraint(_)) => {
+                // We push to outbound on UniqueConstraint error because in sse_server we match shutdowns to outbounds based on the filter they came from to prevent duplicates.
+                // But that also means that we need to pass through all the Shutdown events so the sse_server can determine to which outbound filters they need to be pushed (we
+                // don't store in DB the information from which filter did shutdown came).
+                if let Err(error) = self
+                    .outbound_sse_data_sender
+                    .send((SseData::Shutdown, Some(sse_event.inbound_filter)))
+                    .await
+                {
+                    debug!(
+                        "Error when sending to outbound_sse_data_sender. Error: {}",
+                        error
+                    );
+                }
+            }
+            Err(other_err) => {
+                count_error("db_save_error_shutdown");
+                warn!(?other_err, "Unexpected error saving Shutdown")
+            }
+        }
+    }
+}

--- a/event_sidecar/src/event_handling_service/no_db_event_handling_service.rs
+++ b/event_sidecar/src/event_handling_service/no_db_event_handling_service.rs
@@ -1,0 +1,215 @@
+use crate::{
+    event_handling_service::handle_database_save_result, transaction_hash_to_identifier, Fault,
+    FinalitySignature, Step, TransactionAccepted, TransactionProcessed,
+};
+use async_trait::async_trait;
+use casper_event_listener::SseEvent;
+use casper_event_types::{sse_data::SseData, Filter};
+use casper_types::{
+    Block, BlockHash, EraId, ProtocolVersion, PublicKey, Timestamp, TransactionHash,
+};
+use derive_new::new;
+use hex_fmt::HexFmt;
+use metrics::sse::observe_contract_messages;
+use tokio::sync::mpsc::Sender;
+use tracing::{debug, info, warn};
+
+use super::EventHandlingService;
+
+#[derive(new, Clone)]
+pub struct NoDbEventHandlingService {
+    outbound_sse_data_sender: Sender<(SseData, Option<Filter>)>,
+    enable_event_logging: bool,
+}
+
+#[async_trait]
+impl EventHandlingService for NoDbEventHandlingService {
+    async fn handle_api_version(&self, version: ProtocolVersion, filter: Filter) {
+        if let Err(error) = self
+            .outbound_sse_data_sender
+            .send((SseData::ApiVersion(version), Some(filter)))
+            .await
+        {
+            debug!(
+                "Error when sending to outbound_sse_data_sender. Error: {}",
+                error
+            );
+        }
+        if self.enable_event_logging {
+            info!(%version, "API Version");
+        }
+    }
+
+    async fn handle_block_added(
+        &self,
+        block_hash: BlockHash,
+        _block: Box<Block>,
+        sse_event: SseEvent,
+    ) {
+        if self.enable_event_logging {
+            let hex_block_hash = HexFmt(block_hash.inner());
+            info!("Block Added: {:18}", hex_block_hash);
+            debug!("Block Added: {}", hex_block_hash);
+        }
+        let filter = sse_event.inbound_filter;
+        handle_database_save_result(
+            "BlockAdded",
+            HexFmt(block_hash.inner()).to_string().as_str(),
+            Ok(()),
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_transaction_accepted(
+        &self,
+        transaction_accepted: TransactionAccepted,
+        sse_event: SseEvent,
+    ) {
+        let entity_identifier = transaction_accepted.identifier();
+        if self.enable_event_logging {
+            info!("Transaction Accepted: {:18}", entity_identifier);
+            debug!("Transaction Accepted: {}", entity_identifier);
+        }
+        let filter = sse_event.inbound_filter;
+        handle_database_save_result(
+            "TransactionAccepted",
+            &entity_identifier,
+            Ok(()),
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_transaction_expired(
+        &self,
+        transaction_hash: TransactionHash,
+        sse_event: SseEvent,
+    ) {
+        let entity_identifier = transaction_hash_to_identifier(&transaction_hash);
+        if self.enable_event_logging {
+            info!("Transaction Expired: {:18}", entity_identifier);
+            debug!("Transaction Expired: {}", entity_identifier);
+        }
+        let filter = sse_event.inbound_filter;
+        handle_database_save_result(
+            "TransactionExpired",
+            &entity_identifier,
+            Ok(()),
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_transaction_processed(
+        &self,
+        transaction_processed: TransactionProcessed,
+        sse_event: SseEvent,
+    ) {
+        let entity_identifier = transaction_processed.identifier();
+        if self.enable_event_logging {
+            info!("Transaction Processed: {:18}", entity_identifier);
+            debug!("Transaction Processed: {}", entity_identifier);
+        }
+        let filter = sse_event.inbound_filter;
+        let messages_len = transaction_processed.messages().len();
+
+        if messages_len > 0 {
+            observe_contract_messages("all", messages_len);
+        }
+        handle_database_save_result(
+            "TransactionProcessed",
+            &entity_identifier,
+            Ok(()),
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_fault(
+        &self,
+        era_id: EraId,
+        timestamp: Timestamp,
+        public_key: PublicKey,
+        sse_event: SseEvent,
+    ) {
+        let filter = sse_event.inbound_filter;
+        let fault_identifier = format!("{}-{}", era_id.value(), public_key);
+        let fault = Fault::new(era_id, public_key, timestamp);
+        warn!(%fault, "Fault reported");
+
+        handle_database_save_result(
+            "Fault",
+            &fault_identifier,
+            Ok(()),
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_step(&self, step: Step, sse_event: SseEvent) {
+        let era_id = step.era_id;
+        let step_identifier = format!("{}", era_id.value());
+        if self.enable_event_logging {
+            info!("Step at era: {}", step_identifier);
+        }
+        let filter = sse_event.inbound_filter;
+        handle_database_save_result(
+            "Step",
+            step_identifier.as_str(),
+            Ok(()),
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_finality_signature(
+        &self,
+        finality_signature: FinalitySignature,
+        sse_event: SseEvent,
+    ) {
+        if self.enable_event_logging {
+            debug!(
+                "Finality Signature: {} for {}",
+                finality_signature.signature(),
+                finality_signature.block_hash()
+            );
+        }
+        let filter = sse_event.inbound_filter;
+        handle_database_save_result(
+            "FinalitySignature",
+            "",
+            Ok(()),
+            &self.outbound_sse_data_sender,
+            filter,
+            sse_event.data,
+        )
+        .await;
+    }
+
+    async fn handle_shutdown(&self, sse_event: SseEvent) {
+        warn!("Node ({}) is unavailable", sse_event.source.to_string());
+        if let Err(error) = self
+            .outbound_sse_data_sender
+            .send((SseData::Shutdown, Some(sse_event.inbound_filter)))
+            .await
+        {
+            debug!(
+                "Error when sending to outbound_sse_data_sender. Error: {}",
+                error
+            );
+        }
+    }
+}

--- a/event_sidecar/src/tests/performance_tests.rs
+++ b/event_sidecar/src/tests/performance_tests.rs
@@ -264,7 +264,7 @@ async fn performance_check(scenario: Scenario, duration: Duration, acceptable_la
     let test_rng = TestRng::new();
 
     let temp_storage_dir = tempdir().expect("Should have created a temporary storage directory");
-    let mut testing_config = prepare_config(&temp_storage_dir);
+    let mut testing_config = prepare_config(&temp_storage_dir, true);
     testing_config.add_connection(None, None, None);
     let node_port_for_sse_connection = testing_config
         .event_server_config
@@ -387,7 +387,7 @@ async fn live_performance_check(
     acceptable_latency: Duration,
 ) {
     let temp_storage_dir = tempdir().expect("Should have created a temporary storage directory");
-    let mut testing_config = prepare_config(&temp_storage_dir);
+    let mut testing_config = prepare_config(&temp_storage_dir, true);
     let port_for_connection = testing_config.add_connection(Some(ip_address.clone()), Some(port));
 
     tokio::spawn(run(testing_config.inner()));

--- a/event_sidecar/src/types/sse_events.rs
+++ b/event_sidecar/src/types/sse_events.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 use casper_types::ChainNameDigest;
-use casper_types::FinalitySignature as FinSig;
 use casper_types::{
     contract_messages::Messages, execution::ExecutionResult, AsymmetricType, Block, BlockHash,
     EraId, InitiatorAddr, ProtocolVersion, PublicKey, TimeDiff, Timestamp, Transaction,
@@ -12,6 +11,7 @@ use casper_types::{
     testing::TestRng,
     TestBlockBuilder, TestBlockV1Builder,
 };
+use casper_types::{FinalitySignature as FinSig, Signature};
 use derive_new::new;
 use hex::ToHex;
 #[cfg(test)]
@@ -101,6 +101,10 @@ impl TransactionAccepted {
             Transaction::Deploy(_) => TransactionTypeId::Deploy,
             Transaction::V1(_) => TransactionTypeId::Version1,
         }
+    }
+
+    pub fn transaction(&self) -> Arc<Transaction> {
+        self.transaction.clone()
     }
 
     #[cfg(test)]
@@ -196,6 +200,10 @@ impl TransactionProcessed {
             TransactionHash::V1(v1_hash) => v1_hash.encode_hex(),
         }
     }
+
+    pub fn messages(&self) -> &Messages {
+        &self.messages
+    }
 }
 
 /// The given transaction has expired.
@@ -214,6 +222,9 @@ impl TransactionExpired {
             TransactionHash::Deploy(_) => TransactionTypeId::Deploy,
             TransactionHash::V1(_) => TransactionTypeId::Version1,
         }
+    }
+    pub fn transaction_hash(&self) -> TransactionHash {
+        self.transaction_hash
     }
 
     #[cfg(test)]
@@ -298,6 +309,14 @@ impl FinalitySignature {
         *self.0.clone()
     }
 
+    pub fn signature(&self) -> &Signature {
+        self.0.signature()
+    }
+
+    pub fn block_hash(&self) -> &BlockHash {
+        self.0.block_hash()
+    }
+
     pub fn hex_encoded_block_hash(&self) -> String {
         hex::encode(self.0.block_hash().inner())
     }
@@ -330,7 +349,7 @@ impl Step {
     }
 }
 
-fn transaction_hash_to_identifier(transaction_hash: &TransactionHash) -> String {
+pub fn transaction_hash_to_identifier(transaction_hash: &TransactionHash) -> String {
     match transaction_hash {
         TransactionHash::Deploy(deploy) => hex::encode(deploy.inner()),
         TransactionHash::V1(transaction) => hex::encode(transaction.inner()),

--- a/resources/ETC_README.md
+++ b/resources/ETC_README.md
@@ -1,12 +1,12 @@
 # Casper Sidecar README for Node Operators
 
 This page contains specific instructions for node operators. Before proceeding, familiarize yourself with the main [README](../README.md) file, which covers the following:
- - [Summary of purpose](../README.md#summary-of-purpose)
- - [System components and architecture](../README.md#system-components-and-architecture)
- - [Configuration options](../README.md#configuring-the-sidecar)
- - [Running and testing the Sidecar](../README.md#running-and-testing-the-sidecar)
- - [Troubleshooting tips](../README.md#troubleshooting-tips)
 
+- [Summary of purpose](../README.md#summary-of-purpose)
+- [System components and architecture](../README.md#system-components-and-architecture)
+- [Configuration options](../README.md#configuring-the-sidecar)
+- [Running and testing the Sidecar](../README.md#running-and-testing-the-sidecar)
+- [Troubleshooting tips](../README.md#troubleshooting-tips)
 
 ## Configuring the Sidecar
 
@@ -16,10 +16,9 @@ If you install the Sidecar on an external server, you must update the `ip-addres
 
 For more information, including how to setup the SSE, RPC, REST, and Admin servers, read the [configuration options](../README.md#configuring-the-sidecar) in the main README.
 
-
 ## Installing the Sidecar on a Node
 
-The following command will install the Debian package for the Casper Sidecar service on various flavors of Linux. 
+The following command will install the Debian package for the Casper Sidecar service on various flavors of Linux.
 
 <!-- TODO Once the package is published, update the command below with the new link to the *.deb package. The link below assumes a package available locally. -->
 
@@ -53,6 +52,40 @@ The `casper-sidecar` service starts after installation, using the systemd servic
 
 `sudo systemctl start casper-sidecar.service`
 
+## Sidecar Storage
+
+This directory stores the SSE cache and an SQLite database if the Sidecar was configured to use SQLite.
+
+```toml
+[storage]
+storage_folder = "./target/storage"
+```
+
+Check the service status:
+
+```bash
+systemctl status casper-sidecar
+```
+
+Check the logs and make sure the service is running as expected.
+
+```bash
+journalctl --no-pager -u casper-sidecar
+```
+
+If you see any errors, you may need to [update the configuration](#configuring-the-service) and restart the service with the commands below.
+
+## Running the Sidecar on a Node
+
+The `casper-sidecar` service starts after installation, using the systemd service file.
+
+### Stop
+
+`sudo systemctl stop casper-sidecar.service`
+
+### Start
+
+`sudo systemctl start casper-sidecar.service`
 
 ## Sidecar Storage
 

--- a/resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
@@ -28,6 +28,7 @@ max_attempts = 30
 
 [sse_server]
 enable_server = true
+disable_event_persistence = false
 
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
@@ -69,20 +70,23 @@ max_concurrent_subscribers = 100
 event_stream_buffer_length = 5000
 
 [storage]
-storage_path = "./target/storage"
+storage_folder = "/var/lib/casper-sidecar"
 
 [storage.sqlite_config]
+enabled = true
 file_name = "sqlite_database.db3"
 max_connections_in_pool = 100
 # https://www.sqlite.org/compile.html#default_wal_autocheckpoint
 wal_autocheckpointing_interval = 1000
 
 [rest_api_server]
+enable_server = true
 port = 18888
 max_concurrent_requests = 50
 max_requests_per_second = 50
 
 [admin_api_server]
+enable_server = true
 port = 18887
 max_concurrent_requests = 1
 max_requests_per_second = 1

--- a/resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml
@@ -28,6 +28,7 @@ max_attempts = 30
 
 [sse_server]
 enable_server = true
+disable_event_persistence = false
 
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
@@ -69,9 +70,10 @@ max_concurrent_subscribers = 100
 event_stream_buffer_length = 5000
 
 [storage]
-storage_path = "./target/storage"
+storage_folder = "/var/lib/casper-sidecar"
 
 [storage.postgresql_config]
+enabled = true
 database_name = "event_sidecar"
 host = "localhost"
 database_password = "p@$$w0rd"
@@ -79,6 +81,7 @@ database_username = "postgres"
 max_connections_in_pool = 30
 
 [rest_api_server]
+enable_server = true
 port = 18888
 max_concurrent_requests = 50
 max_requests_per_second = 50

--- a/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
@@ -28,6 +28,7 @@ max_attempts = 30
 
 [sse_server]
 enable_server = true
+disable_event_persistence = false
 
 [[sse_server.connections]]
 ip_address = "168.254.51.1"
@@ -68,20 +69,23 @@ max_concurrent_subscribers = 100
 event_stream_buffer_length = 5000
 
 [storage]
-storage_path = "/var/lib/casper-sidecar"
+storage_folder = "/var/lib/casper-sidecar"
 
 [storage.sqlite_config]
+enabled = true
 file_name = "sqlite_database.db3"
 max_connections_in_pool = 100
 # https://www.sqlite.org/compile.html#default_wal_autocheckpoint
 wal_autocheckpointing_interval = 1000
 
 [rest_api_server]
+enable_server = true
 port = 18888
 max_concurrent_requests = 50
 max_requests_per_second = 50
 
 [admin_api_server]
+enable_server = true
 port = 18887
 max_concurrent_requests = 1
 max_requests_per_second = 1

--- a/resources/example_configs/default_sse_only_config.toml
+++ b/resources/example_configs/default_sse_only_config.toml
@@ -1,3 +1,7 @@
+[sse_server]
+enable_server = true
+disable_event_persistence = false
+
 [[sse_server.connections]]
 ip_address = "127.0.0.1"
 sse_port = 9999
@@ -13,20 +17,23 @@ max_concurrent_subscribers = 100
 event_stream_buffer_length = 5000
 
 [storage]
-storage_path = "/var/lib/casper-sidecar"
+storage_folder = "/var/lib/casper-sidecar"
 
 [storage.sqlite_config]
+enabled = true
 file_name = "sqlite_database.db3"
 max_connections_in_pool = 100
 # https://www.sqlite.org/compile.html#default_wal_autocheckpoint
 wal_autocheckpointing_interval = 1000
 
 [rest_api_server]
+enable_server = true
 port = 18888
 max_concurrent_requests = 50
 max_requests_per_second = 50
 
 [admin_server]
+enable_server = true
 port = 18887
 max_concurrent_requests = 1
 max_requests_per_second = 1

--- a/sidecar/src/run.rs
+++ b/sidecar/src/run.rs
@@ -6,9 +6,8 @@ use std::process::ExitCode;
 use tracing::info;
 
 pub async fn run(config: SidecarConfig) -> Result<ExitCode, Error> {
-    let maybe_database = config
-        .storage
-        .as_ref()
+    let maybe_database = Some(&config.storage)
+        .filter(|storage_config| storage_config.is_enabled())
         .map(|storage_config| LazyDatabaseWrapper::new(storage_config.clone()));
     let mut components: Vec<Box<dyn Component>> = Vec::new();
     let admin_api_component = AdminApiComponent::new();

--- a/types/src/legacy_sse_data/translate_block_added.rs
+++ b/types/src/legacy_sse_data/translate_block_added.rs
@@ -36,7 +36,6 @@ impl EraEndV2Translator for DefaultEraEndV2Translator {
                 //We're not able to cast the reward to u64, so we skip this era end.
                 return None;
             }
-            println!("Reward: {:?} {:?}", k.clone(), amount);
             rewards.insert(k.clone(), amount.as_u64());
         }
         let era_report = EraReport::new(


### PR DESCRIPTION
…ection has a `disable_event_persistence` property. If set to true, Sidecar will not store events to database. [storage.sqlite_config] and [storage.postgresql_config] are optional. Also [storage.sqlite_config] and [storage.postgresql_config] have `enabled` property. If set to false, Sidecar will treat them as if they are not defined at all. Changed the name of [storage.storage_path] to [storage.storage_folder]