### PR TITLE
Remove dependency on `casper-node/binary-port`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,6 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=feat-2.0#79714924f7a83d98e0d3037fef60fcb66ce4ef54"
 dependencies = [
  "bincode",
  "bytes",
@@ -480,7 +479,8 @@ dependencies = [
  "rand",
  "schemars",
  "serde",
- "serde-map-to-array",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror",
  "tokio-util 0.6.10",
 ]
@@ -4364,6 +4364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,6 +4389,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "rustversion",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "rustversion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1"
 async-stream = "0.3.4"
 async-trait = "0.1.77"
 casper-types = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0", features = ["json-schema"]}
-casper-binary-port = { git = "https://github.com/casper-network/casper-node.git", branch = "feat-2.0" }
+casper-binary-port = { path = "./binary_port", version = "1.0.0" }
 casper-event-sidecar = { path = "./event_sidecar", version = "1.0.0" }
 casper-event-types = { path = "./types", version = "1.0.0" }
 casper-rpc-sidecar = { path = "./rpc_sidecar", version = "1.0.0" }

--- a/binary_port/Cargo.toml
+++ b/binary_port/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "casper-binary-port"
+version = "1.0.0"
+edition = "2021"
+description = "Types for the casper node binary port"
+license-file = "../LICENSE"
+documentation = "../README.md"
+homepage = "https://github.com/casper-network/casper-sidecar/"
+repository = "https://github.com/casper-network/casper-sidecar/"
+
+[dependencies]
+bincode = "1.3.3"
+bytes = "1.0.1"
+casper-types = { workspace = true, features = ["std"] }
+once_cell = { workspace = true }
+rand = { version = "0.8.5", optional = true }
+schemars = { version = "0.8.16", features = ["preserve_order", "impl_json_schema"] }
+serde = { workspace = true, default-features = true, features = ["derive", "rc"] }
+strum = "0.26.2"
+strum_macros = "0.26.4"
+tokio-util = { version = "0.6.4", features = ["codec"] }
+thiserror = { workspace = true }
+
+[features]
+testing = ["rand/default"]
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/binary_port/src/balance_response.rs
+++ b/binary_port/src/balance_response.rs
@@ -1,0 +1,105 @@
+use std::collections::BTreeMap;
+#[cfg(test)]
+use std::{collections::VecDeque, iter::FromIterator};
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    global_state::TrieMerkleProof,
+    system::mint::BalanceHoldAddrTag,
+    BlockTime, Key, StoredValue, U512,
+};
+#[cfg(test)]
+use casper_types::{global_state::TrieMerkleProofStep, CLValue};
+#[cfg(test)]
+use rand::Rng;
+
+/// Response to a balance query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BalanceResponse {
+    /// The purses total balance, not considering holds.
+    pub total_balance: U512,
+    /// The available balance (total balance - sum of all active holds).
+    pub available_balance: U512,
+    /// A proof that the given value is present in the Merkle trie.
+    pub total_balance_proof: Box<TrieMerkleProof<Key, StoredValue>>,
+    /// Any time-relevant active holds on the balance.
+    pub balance_holds: BTreeMap<BlockTime, BalanceHoldsWithProof>,
+}
+
+impl BalanceResponse {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        BalanceResponse {
+            total_balance: rng.gen(),
+            available_balance: rng.gen(),
+            total_balance_proof: Box::new(TrieMerkleProof::new(
+                Key::URef(rng.gen()),
+                StoredValue::CLValue(CLValue::from_t(rng.gen::<i32>()).unwrap()),
+                VecDeque::from_iter([TrieMerkleProofStep::random(rng)]),
+            )),
+            balance_holds: BTreeMap::new(),
+        }
+    }
+}
+
+impl ToBytes for BalanceResponse {
+    fn to_bytes(&self) -> Result<Vec<u8>, casper_types::bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), casper_types::bytesrepr::Error> {
+        self.total_balance.write_bytes(writer)?;
+        self.available_balance.write_bytes(writer)?;
+        self.total_balance_proof.write_bytes(writer)?;
+        self.balance_holds.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.total_balance.serialized_length()
+            + self.available_balance.serialized_length()
+            + self.total_balance_proof.serialized_length()
+            + self.balance_holds.serialized_length()
+    }
+}
+
+impl FromBytes for BalanceResponse {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), casper_types::bytesrepr::Error> {
+        let (total_balance, remainder) = U512::from_bytes(bytes)?;
+        let (available_balance, remainder) = U512::from_bytes(remainder)?;
+        let (total_balance_proof, remainder) =
+            TrieMerkleProof::<Key, StoredValue>::from_bytes(remainder)?;
+        let (balance_holds, remainder) =
+            BTreeMap::<BlockTime, BalanceHoldsWithProof>::from_bytes(remainder)?;
+        Ok((
+            BalanceResponse {
+                total_balance,
+                available_balance,
+                total_balance_proof: Box::new(total_balance_proof),
+                balance_holds,
+            },
+            remainder,
+        ))
+    }
+}
+
+/// Balance holds with Merkle proofs.
+pub type BalanceHoldsWithProof =
+    BTreeMap<BalanceHoldAddrTag, (U512, TrieMerkleProof<Key, StoredValue>)>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = BalanceResponse::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/binary_message.rs
+++ b/binary_port/src/binary_message.rs
@@ -1,0 +1,272 @@
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+use bytes::{Buf, Bytes};
+use tokio_util::codec::{self};
+
+use crate::error::Error;
+
+type LengthEncoding = u32;
+const LENGTH_ENCODING_SIZE_BYTES: usize = std::mem::size_of::<LengthEncoding>();
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct BinaryMessage(Bytes);
+
+impl BinaryMessage {
+    pub fn new(payload: Vec<u8>) -> Self {
+        Self(payload.into())
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        let len = rng.gen_range(1..=1024);
+        let payload = std::iter::repeat_with(|| rng.gen()).take(len).collect();
+        BinaryMessage(payload)
+    }
+}
+
+pub struct BinaryMessageCodec {
+    max_message_size_bytes: u32,
+}
+
+impl BinaryMessageCodec {
+    pub fn new(max_message_size_bytes: u32) -> Self {
+        Self {
+            max_message_size_bytes,
+        }
+    }
+
+    pub fn max_message_size_bytes(&self) -> u32 {
+        self.max_message_size_bytes
+    }
+}
+
+impl codec::Encoder<BinaryMessage> for BinaryMessageCodec {
+    type Error = Error;
+
+    fn encode(
+        &mut self,
+        item: BinaryMessage,
+        dst: &mut bytes::BytesMut,
+    ) -> Result<(), Self::Error> {
+        let length = item.0.len() as LengthEncoding;
+        if length > self.max_message_size_bytes {
+            return Err(Error::RequestTooLarge {
+                allowed: self.max_message_size_bytes,
+                got: length,
+            });
+        }
+        let length_bytes = length.to_le_bytes();
+        dst.extend(length_bytes.iter().chain(item.0.iter()));
+        Ok(())
+    }
+}
+
+impl codec::Decoder for BinaryMessageCodec {
+    type Item = BinaryMessage;
+
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let (length, have_full_frame) = if let [b1, b2, b3, b4, remainder @ ..] = &src[..] {
+            let length = LengthEncoding::from_le_bytes([*b1, *b2, *b3, *b4]) as usize;
+            (length, remainder.len() >= length)
+        } else {
+            // Not enough bytes to read the length.
+            return Ok(None);
+        };
+
+        if !have_full_frame {
+            // Not enough bytes to read the whole message.
+            return Ok(None);
+        };
+
+        if length > self.max_message_size_bytes as usize {
+            return Err(Error::RequestTooLarge {
+                allowed: self.max_message_size_bytes,
+                got: length as u32,
+            });
+        }
+        if length == 0 {
+            return Err(Error::EmptyRequest);
+        }
+
+        src.advance(LENGTH_ENCODING_SIZE_BYTES);
+        Ok(Some(BinaryMessage(src.split_to(length).freeze())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use casper_types::testing::TestRng;
+    use rand::Rng;
+    use tokio_util::codec::{Decoder, Encoder};
+
+    use crate::{
+        binary_message::{LengthEncoding, LENGTH_ENCODING_SIZE_BYTES},
+        error::Error,
+        BinaryMessage, BinaryMessageCodec,
+    };
+
+    const MAX_MESSAGE_SIZE_BYTES: u32 = 1024 * 1024;
+
+    #[test]
+    fn binary_message_codec() {
+        let rng = &mut TestRng::new();
+        let val = BinaryMessage::random(rng);
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let mut bytes = bytes::BytesMut::new();
+        codec
+            .encode(val.clone(), &mut bytes)
+            .expect("should encode");
+
+        let decoded = codec
+            .decode(&mut bytes)
+            .expect("should decode")
+            .expect("should be Some");
+
+        assert_eq!(val, decoded);
+    }
+
+    #[test]
+    fn should_not_decode_when_not_enough_bytes_to_decode_length() {
+        let rng = &mut TestRng::new();
+        let val = BinaryMessage::random(rng);
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let mut bytes = bytes::BytesMut::new();
+        codec.encode(val, &mut bytes).expect("should encode");
+
+        let _ = bytes.split_off(LENGTH_ENCODING_SIZE_BYTES / 2);
+        let in_bytes = bytes.clone();
+        assert!(codec.decode(&mut bytes).expect("should decode").is_none());
+
+        // Ensure that the bytes are not consumed.
+        assert_eq!(in_bytes, bytes);
+    }
+
+    #[test]
+    fn should_not_decode_when_not_enough_bytes_to_decode_full_frame() {
+        let rng = &mut TestRng::new();
+        let val = BinaryMessage::random(rng);
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let mut bytes = bytes::BytesMut::new();
+        codec.encode(val, &mut bytes).expect("should encode");
+
+        let _ = bytes.split_off(bytes.len() - 1);
+        let in_bytes = bytes.clone();
+        assert!(codec.decode(&mut bytes).expect("should decode").is_none());
+
+        // Ensure that the bytes are not consumed.
+        assert_eq!(in_bytes, bytes);
+    }
+
+    #[test]
+    fn should_leave_remainder_in_buffer() {
+        let rng = &mut TestRng::new();
+        let val = BinaryMessage::random(rng);
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let mut bytes = bytes::BytesMut::new();
+        codec.encode(val, &mut bytes).expect("should encode");
+        let suffix = bytes::Bytes::from_static(b"suffix");
+        bytes.extend(&suffix);
+
+        let _ = codec.decode(&mut bytes);
+
+        // Ensure that the bytes are not consumed.
+        assert_eq!(bytes, suffix);
+    }
+
+    #[test]
+    fn encode_should_bail_on_too_large_request() {
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let too_large = MAX_MESSAGE_SIZE_BYTES as usize + 1;
+        let val = BinaryMessage::new(vec![0; too_large]);
+        let mut bytes = bytes::BytesMut::new();
+        let result = codec.encode(val, &mut bytes).unwrap_err();
+
+        assert!(matches!(result, Error::RequestTooLarge { allowed, got }
+                 if allowed == codec.max_message_size_bytes && got == too_large as u32));
+    }
+
+    #[test]
+    fn should_encode_request_of_maximum_size() {
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let just_right_size = MAX_MESSAGE_SIZE_BYTES as usize;
+        let val = BinaryMessage::new(vec![0; just_right_size]);
+        let mut bytes = bytes::BytesMut::new();
+
+        let result = codec.encode(val, &mut bytes);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn decode_should_bail_on_too_large_request() {
+        let rng = &mut TestRng::new();
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let mut bytes = bytes::BytesMut::new();
+        let too_large = (codec.max_message_size_bytes + 1) as LengthEncoding;
+        bytes.extend(too_large.to_le_bytes());
+        bytes.extend(std::iter::repeat_with(|| rng.gen::<u8>()).take(too_large as usize));
+
+        let result = codec.decode(&mut bytes).unwrap_err();
+        assert!(matches!(result, Error::RequestTooLarge { allowed, got }
+                 if allowed == codec.max_message_size_bytes && got == too_large));
+    }
+
+    #[test]
+    fn should_decode_request_of_maximum_size() {
+        let rng = &mut TestRng::new();
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let mut bytes = bytes::BytesMut::new();
+        let just_right_size = (codec.max_message_size_bytes) as LengthEncoding;
+        bytes.extend(just_right_size.to_le_bytes());
+        bytes.extend(std::iter::repeat_with(|| rng.gen::<u8>()).take(just_right_size as usize));
+
+        let result = codec.decode(&mut bytes);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn should_bail_on_empty_request() {
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let mut bytes = bytes::BytesMut::new();
+        let empty = 0 as LengthEncoding;
+        bytes.extend(&empty.to_le_bytes());
+
+        let result = codec.decode(&mut bytes).unwrap_err();
+        assert!(matches!(result, Error::EmptyRequest));
+    }
+
+    #[test]
+    fn should_decoded_queued_messages() {
+        let rng = &mut TestRng::new();
+        let count = rng.gen_range(10000..20000);
+        let messages = (0..count)
+            .map(|_| BinaryMessage::random(rng))
+            .collect::<Vec<_>>();
+        let mut codec = BinaryMessageCodec::new(MAX_MESSAGE_SIZE_BYTES);
+        let mut bytes = bytes::BytesMut::new();
+        for msg in &messages {
+            codec
+                .encode(msg.clone(), &mut bytes)
+                .expect("should encode");
+        }
+
+        let mut decoded_messages = vec![];
+        loop {
+            let maybe_message = codec.decode(&mut bytes).expect("should decode");
+            match maybe_message {
+                Some(message) => decoded_messages.push(message),
+                None => break,
+            }
+        }
+
+        assert_eq!(messages, decoded_messages);
+    }
+}

--- a/binary_port/src/binary_request.rs
+++ b/binary_port/src/binary_request.rs
@@ -1,0 +1,281 @@
+use core::convert::TryFrom;
+
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    ProtocolVersion, Transaction,
+};
+
+use crate::GetRequest;
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+/// The header of a binary request.
+#[derive(Debug, PartialEq)]
+pub struct BinaryRequestHeader {
+    binary_request_version: u16,
+    chain_protocol_version: ProtocolVersion,
+    type_tag: u8,
+    id: u16,
+}
+
+impl BinaryRequestHeader {
+    // Defines the current version of the header, in practice defining the current version of the
+    // binary port protocol. Requests with mismatched header version will be dropped.
+    pub const BINARY_REQUEST_VERSION: u16 = 0;
+
+    /// Creates new binary request header.
+    pub fn new(protocol_version: ProtocolVersion, type_tag: BinaryRequestTag, id: u16) -> Self {
+        Self {
+            chain_protocol_version: protocol_version,
+            binary_request_version: Self::BINARY_REQUEST_VERSION,
+            type_tag: type_tag.into(),
+            id,
+        }
+    }
+
+    /// Returns the protocol version of the request.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.chain_protocol_version
+    }
+
+    /// Returns the type tag of the request.
+    pub fn type_tag(&self) -> u8 {
+        self.type_tag
+    }
+
+    /// Returns the request id.
+    pub fn id(&self) -> u16 {
+        self.id
+    }
+
+    /// Returns the header version.
+    pub fn version(&self) -> u16 {
+        self.binary_request_version
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn set_binary_request_version(&mut self, version: u16) {
+        self.binary_request_version = version;
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn set_chain_protocol_version(&mut self, protocol_version: ProtocolVersion) {
+        self.chain_protocol_version = protocol_version;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        Self {
+            chain_protocol_version: ProtocolVersion::from_parts(rng.gen(), rng.gen(), rng.gen()),
+            binary_request_version: rng.gen(),
+            type_tag: BinaryRequestTag::random(rng).into(),
+            id: rng.gen(),
+        }
+    }
+}
+
+impl ToBytes for BinaryRequestHeader {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.binary_request_version.write_bytes(writer)?;
+        self.chain_protocol_version.write_bytes(writer)?;
+        self.type_tag.write_bytes(writer)?;
+        self.id.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.binary_request_version.serialized_length()
+            + self.chain_protocol_version.serialized_length()
+            + self.type_tag.serialized_length()
+            + self.id.serialized_length()
+    }
+}
+
+impl FromBytes for BinaryRequestHeader {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (binary_request_version, remainder) = FromBytes::from_bytes(bytes)?;
+        let (chain_protocol_version, remainder) = FromBytes::from_bytes(remainder)?;
+        let (type_tag, remainder) = FromBytes::from_bytes(remainder)?;
+        let (id, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((
+            BinaryRequestHeader {
+                chain_protocol_version,
+                binary_request_version,
+                type_tag,
+                id,
+            },
+            remainder,
+        ))
+    }
+}
+
+/// A request to the binary access interface.
+#[derive(Debug, PartialEq)]
+pub enum BinaryRequest {
+    /// Request to get data from the node
+    Get(GetRequest),
+    /// Request to add a transaction into a blockchain.
+    TryAcceptTransaction {
+        /// Transaction to be handled.
+        transaction: Transaction,
+    },
+    /// Request to execute a transaction speculatively.
+    TrySpeculativeExec {
+        /// Transaction to execute.
+        transaction: Transaction,
+    },
+}
+
+impl BinaryRequest {
+    /// Returns the type tag of the request.
+    pub fn tag(&self) -> BinaryRequestTag {
+        match self {
+            BinaryRequest::Get(_) => BinaryRequestTag::Get,
+            BinaryRequest::TryAcceptTransaction { .. } => BinaryRequestTag::TryAcceptTransaction,
+            BinaryRequest::TrySpeculativeExec { .. } => BinaryRequestTag::TrySpeculativeExec,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match BinaryRequestTag::random(rng) {
+            BinaryRequestTag::Get => Self::Get(GetRequest::random(rng)),
+            BinaryRequestTag::TryAcceptTransaction => Self::TryAcceptTransaction {
+                transaction: Transaction::random(rng),
+            },
+            BinaryRequestTag::TrySpeculativeExec => Self::TrySpeculativeExec {
+                transaction: Transaction::random(rng),
+            },
+        }
+    }
+}
+
+impl ToBytes for BinaryRequest {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            BinaryRequest::Get(inner) => inner.write_bytes(writer),
+            BinaryRequest::TryAcceptTransaction { transaction } => transaction.write_bytes(writer),
+            BinaryRequest::TrySpeculativeExec { transaction } => transaction.write_bytes(writer),
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        match self {
+            BinaryRequest::Get(inner) => inner.serialized_length(),
+            BinaryRequest::TryAcceptTransaction { transaction } => transaction.serialized_length(),
+            BinaryRequest::TrySpeculativeExec { transaction } => transaction.serialized_length(),
+        }
+    }
+}
+
+impl TryFrom<(BinaryRequestTag, &[u8])> for BinaryRequest {
+    type Error = bytesrepr::Error;
+
+    fn try_from((tag, bytes): (BinaryRequestTag, &[u8])) -> Result<Self, Self::Error> {
+        let (req, remainder) = match tag {
+            BinaryRequestTag::Get => {
+                let (get_request, remainder) = FromBytes::from_bytes(bytes)?;
+                (BinaryRequest::Get(get_request), remainder)
+            }
+            BinaryRequestTag::TryAcceptTransaction => {
+                let (transaction, remainder) = FromBytes::from_bytes(bytes)?;
+                (
+                    BinaryRequest::TryAcceptTransaction { transaction },
+                    remainder,
+                )
+            }
+            BinaryRequestTag::TrySpeculativeExec => {
+                let (transaction, remainder) = FromBytes::from_bytes(bytes)?;
+                (BinaryRequest::TrySpeculativeExec { transaction }, remainder)
+            }
+        };
+        if !remainder.is_empty() {
+            return Err(bytesrepr::Error::LeftOverBytes);
+        }
+        Ok(req)
+    }
+}
+
+/// The type tag of a binary request.
+#[derive(Debug, PartialEq)]
+#[repr(u8)]
+pub enum BinaryRequestTag {
+    /// Request to get data from the node
+    Get = 0,
+    /// Request to add a transaction into a blockchain.
+    TryAcceptTransaction = 1,
+    /// Request to execute a transaction speculatively.
+    TrySpeculativeExec = 2,
+}
+
+impl BinaryRequestTag {
+    /// Creates a random `BinaryRequestTag`.
+    #[cfg(test)]
+    pub fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..3) {
+            0 => BinaryRequestTag::Get,
+            1 => BinaryRequestTag::TryAcceptTransaction,
+            2 => BinaryRequestTag::TrySpeculativeExec,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl TryFrom<u8> for BinaryRequestTag {
+    type Error = InvalidBinaryRequestTag;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(BinaryRequestTag::Get),
+            1 => Ok(BinaryRequestTag::TryAcceptTransaction),
+            2 => Ok(BinaryRequestTag::TrySpeculativeExec),
+            _ => Err(InvalidBinaryRequestTag),
+        }
+    }
+}
+
+impl From<BinaryRequestTag> for u8 {
+    fn from(value: BinaryRequestTag) -> Self {
+        value as u8
+    }
+}
+
+/// Error raised when trying to convert an invalid u8 into a `BinaryRequestTag`.
+pub struct InvalidBinaryRequestTag;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn header_bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = BinaryRequestHeader::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+
+    #[test]
+    fn request_bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = BinaryRequest::random(rng);
+        let bytes = val.to_bytes().expect("should serialize");
+        assert_eq!(BinaryRequest::try_from((val.tag(), &bytes[..])), Ok(val));
+    }
+}

--- a/binary_port/src/binary_response.rs
+++ b/binary_port/src/binary_response.rs
@@ -1,0 +1,159 @@
+use casper_types::{
+    bytesrepr::{self, Bytes, FromBytes, ToBytes},
+    ProtocolVersion,
+};
+
+use crate::{BinaryResponseHeader, ErrorCode, PayloadEntity, ResponseType};
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+
+/// The response used in the binary port protocol.
+#[derive(Debug, PartialEq)]
+pub struct BinaryResponse {
+    /// Header of the binary response.
+    header: BinaryResponseHeader,
+    /// The response.
+    payload: Vec<u8>,
+}
+
+impl BinaryResponse {
+    /// Creates new empty binary response.
+    pub fn new_empty(protocol_version: ProtocolVersion) -> Self {
+        Self {
+            header: BinaryResponseHeader::new(None, protocol_version),
+            payload: vec![],
+        }
+    }
+
+    /// Creates new binary response with error code.
+    pub fn new_error(error: ErrorCode, protocol_version: ProtocolVersion) -> Self {
+        BinaryResponse {
+            header: BinaryResponseHeader::new_error(error, protocol_version),
+            payload: vec![],
+        }
+    }
+
+    /// Creates new binary response from raw bytes.
+    pub fn from_raw_bytes(
+        payload_type: ResponseType,
+        payload: Vec<u8>,
+        protocol_version: ProtocolVersion,
+    ) -> Self {
+        BinaryResponse {
+            header: BinaryResponseHeader::new(Some(payload_type), protocol_version),
+            payload,
+        }
+    }
+
+    /// Creates a new binary response from a value.
+    pub fn from_value<V>(val: V, protocol_version: ProtocolVersion) -> Self
+    where
+        V: ToBytes + PayloadEntity,
+    {
+        ToBytes::to_bytes(&val).map_or(
+            BinaryResponse::new_error(ErrorCode::InternalError, protocol_version),
+            |payload| BinaryResponse {
+                payload,
+                header: BinaryResponseHeader::new(Some(V::RESPONSE_TYPE), protocol_version),
+            },
+        )
+    }
+
+    /// Creates a new binary response from an optional value.
+    pub fn from_option<V>(opt: Option<V>, protocol_version: ProtocolVersion) -> Self
+    where
+        V: ToBytes + PayloadEntity,
+    {
+        match opt {
+            Some(val) => Self::from_value(val, protocol_version),
+            None => Self::new_empty(protocol_version),
+        }
+    }
+
+    /// Returns true if response is success.
+    pub fn is_success(&self) -> bool {
+        self.header.is_success()
+    }
+
+    /// Returns the error code.
+    pub fn error_code(&self) -> u16 {
+        self.header.error_code()
+    }
+
+    /// Returns the payload type of the response.
+    pub fn returned_data_type_tag(&self) -> Option<u8> {
+        self.header.returned_data_type_tag()
+    }
+
+    /// Returns true if the response means that data has not been found.
+    pub fn is_not_found(&self) -> bool {
+        self.header.is_not_found()
+    }
+
+    /// Returns the payload.
+    pub fn payload(&self) -> &[u8] {
+        self.payload.as_ref()
+    }
+
+    /// Returns the protocol version.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.header.protocol_version()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        Self {
+            header: BinaryResponseHeader::random(rng),
+            payload: rng.random_vec(64..128),
+        }
+    }
+}
+
+impl ToBytes for BinaryResponse {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let BinaryResponse { header, payload } = self;
+
+        header.write_bytes(writer)?;
+        payload.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.header.serialized_length() + self.payload.serialized_length()
+    }
+}
+
+impl FromBytes for BinaryResponse {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (header, remainder) = FromBytes::from_bytes(bytes)?;
+        let (payload, remainder) = Bytes::from_bytes(remainder)?;
+
+        Ok((
+            BinaryResponse {
+                header,
+                payload: payload.into(),
+            },
+            remainder,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = BinaryResponse::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/binary_response_and_request.rs
+++ b/binary_port/src/binary_response_and_request.rs
@@ -1,0 +1,158 @@
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    ProtocolVersion,
+};
+
+use crate::{
+    binary_response::BinaryResponse, original_request_context::OriginalRequestContext,
+    response_type::PayloadEntity, ResponseType,
+};
+
+use crate::record_id::RecordId;
+#[cfg(test)]
+use casper_types::testing::TestRng;
+
+/// The binary response along with the original binary request attached.
+#[derive(Debug, PartialEq)]
+pub struct BinaryResponseAndRequest {
+    /// Context of the original request.
+    original_request: OriginalRequestContext,
+    /// The response.
+    response: BinaryResponse,
+}
+
+impl BinaryResponseAndRequest {
+    /// Creates new binary response with the original request attached.
+    pub fn new(
+        data: BinaryResponse,
+        original_request_payload: &[u8],
+        original_request_id: u16,
+    ) -> Self {
+        Self {
+            original_request: OriginalRequestContext::new(
+                original_request_id,
+                original_request_payload.to_vec(),
+            ),
+            response: data,
+        }
+    }
+
+    /// Returns a new binary response with specified data and no original request.
+    pub fn new_test_response<A: PayloadEntity + ToBytes>(
+        record_id: RecordId,
+        data: &A,
+        protocol_version: ProtocolVersion,
+    ) -> BinaryResponseAndRequest {
+        let response = BinaryResponse::from_raw_bytes(
+            ResponseType::from_record_id(record_id, false),
+            data.to_bytes().unwrap(),
+            protocol_version,
+        );
+        Self::new(response, &[], 0)
+    }
+
+    /// Returns a new binary response with specified legacy data and no original request.
+    pub fn new_legacy_test_response<A: PayloadEntity + serde::Serialize>(
+        record_id: RecordId,
+        data: &A,
+        protocol_version: ProtocolVersion,
+    ) -> BinaryResponseAndRequest {
+        let response = BinaryResponse::from_raw_bytes(
+            ResponseType::from_record_id(record_id, true),
+            bincode::serialize(data).unwrap(),
+            protocol_version,
+        );
+        Self::new(response, &[], 0)
+    }
+
+    /// Returns true if response is success.
+    pub fn is_success(&self) -> bool {
+        self.response.is_success()
+    }
+
+    /// Returns the error code.
+    pub fn error_code(&self) -> u16 {
+        self.response.error_code()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        Self {
+            original_request: OriginalRequestContext::random(rng),
+            response: BinaryResponse::random(rng),
+        }
+    }
+
+    /// Returns serialized bytes representing the original request.
+    pub fn original_request_bytes(&self) -> &[u8] {
+        self.original_request.data()
+    }
+
+    /// Returns the original request id.
+    pub fn original_request_id(&self) -> u16 {
+        self.original_request.id()
+    }
+
+    /// Returns the inner binary response.
+    pub fn response(&self) -> &BinaryResponse {
+        &self.response
+    }
+}
+
+impl ToBytes for BinaryResponseAndRequest {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let BinaryResponseAndRequest {
+            original_request,
+            response,
+        } = self;
+
+        original_request.write_bytes(writer)?;
+        response.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.original_request.serialized_length() + self.response.serialized_length()
+    }
+}
+
+impl FromBytes for BinaryResponseAndRequest {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (original_request, remainder) = OriginalRequestContext::from_bytes(bytes)?;
+        let (response, remainder) = FromBytes::from_bytes(remainder)?;
+
+        Ok((
+            BinaryResponseAndRequest {
+                original_request,
+                response,
+            },
+            remainder,
+        ))
+    }
+}
+
+impl From<BinaryResponseAndRequest> for BinaryResponse {
+    fn from(response_and_request: BinaryResponseAndRequest) -> Self {
+        let BinaryResponseAndRequest { response, .. } = response_and_request;
+        response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = BinaryResponseAndRequest::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/binary_response_header.rs
+++ b/binary_port/src/binary_response_header.rs
@@ -1,0 +1,136 @@
+use crate::{error_code::ErrorCode, response_type::ResponseType};
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    ProtocolVersion,
+};
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+/// Header of the binary response.
+#[derive(Debug, PartialEq)]
+pub struct BinaryResponseHeader {
+    protocol_version: ProtocolVersion,
+    error: u16,
+    returned_data_type_tag: Option<u8>,
+}
+
+impl BinaryResponseHeader {
+    /// Creates new binary response header representing success.
+    pub fn new(
+        returned_data_type: Option<ResponseType>,
+        protocol_version: ProtocolVersion,
+    ) -> Self {
+        Self {
+            protocol_version,
+            error: ErrorCode::NoError as u16,
+            returned_data_type_tag: returned_data_type.map(|ty| ty as u8),
+        }
+    }
+
+    /// Creates new binary response header representing error.
+    pub fn new_error(error: ErrorCode, protocol_version: ProtocolVersion) -> Self {
+        Self {
+            protocol_version,
+            error: error as u16,
+            returned_data_type_tag: None,
+        }
+    }
+
+    /// Returns the type of the returned data.
+    pub fn returned_data_type_tag(&self) -> Option<u8> {
+        self.returned_data_type_tag
+    }
+
+    /// Returns the error code.
+    pub fn error_code(&self) -> u16 {
+        self.error
+    }
+
+    /// Returns true if the response represents success.
+    pub fn is_success(&self) -> bool {
+        self.error == ErrorCode::NoError as u16
+    }
+
+    /// Returns true if the response indicates the data was not found.
+    pub fn is_not_found(&self) -> bool {
+        self.error == ErrorCode::NotFound as u16
+    }
+
+    /// Returns the protocol version.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        let protocol_version = ProtocolVersion::from_parts(rng.gen(), rng.gen(), rng.gen());
+        let error = rng.gen();
+        let returned_data_type_tag = if rng.gen() { None } else { Some(rng.gen()) };
+
+        BinaryResponseHeader {
+            protocol_version,
+            error,
+            returned_data_type_tag,
+        }
+    }
+}
+
+impl ToBytes for BinaryResponseHeader {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let Self {
+            protocol_version,
+            error,
+            returned_data_type_tag,
+        } = self;
+
+        protocol_version.write_bytes(writer)?;
+        error.write_bytes(writer)?;
+        returned_data_type_tag.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.protocol_version.serialized_length()
+            + self.error.serialized_length()
+            + self.returned_data_type_tag.serialized_length()
+    }
+}
+
+impl FromBytes for BinaryResponseHeader {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (protocol_version, remainder) = FromBytes::from_bytes(bytes)?;
+        let (error, remainder) = FromBytes::from_bytes(remainder)?;
+        let (returned_data_type_tag, remainder) = FromBytes::from_bytes(remainder)?;
+
+        Ok((
+            BinaryResponseHeader {
+                protocol_version,
+                error,
+                returned_data_type_tag,
+            },
+            remainder,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = BinaryResponseHeader::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/dictionary_item_identifier.rs
+++ b/binary_port/src/dictionary_item_identifier.rs
@@ -1,0 +1,256 @@
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+use casper_types::{
+    account::AccountHash,
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    DictionaryAddr, EntityAddr, HashAddr, URef,
+};
+
+const ACCOUNT_NAMED_KEY_TAG: u8 = 0;
+const CONTRACT_NAMED_KEY_TAG: u8 = 1;
+const ENTITY_NAMED_KEY_TAG: u8 = 2;
+const UREF_TAG: u8 = 3;
+const DICTIONARY_ITEM_TAG: u8 = 4;
+
+/// Options for dictionary item lookups.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DictionaryItemIdentifier {
+    /// Lookup a dictionary item via an accounts named keys.
+    AccountNamedKey {
+        /// The account hash.
+        hash: AccountHash,
+        /// The named key under which the dictionary seed URef is stored.
+        dictionary_name: String,
+        /// The dictionary item key formatted as a string.
+        dictionary_item_key: String,
+    },
+    /// Lookup a dictionary item via a contracts named keys.
+    ContractNamedKey {
+        /// The contract hash.
+        hash: HashAddr,
+        /// The named key under which the dictionary seed URef is stored.
+        dictionary_name: String,
+        /// The dictionary item key formatted as a string.
+        dictionary_item_key: String,
+    },
+    /// Lookup a dictionary item via an entities named keys.
+    EntityNamedKey {
+        /// The entity address.
+        addr: EntityAddr,
+        /// The named key under which the dictionary seed URef is stored.
+        dictionary_name: String,
+        /// The dictionary item key formatted as a string.
+        dictionary_item_key: String,
+    },
+    /// Lookup a dictionary item via its seed URef.
+    URef {
+        /// The dictionary's seed URef.
+        seed_uref: URef,
+        /// The dictionary item key formatted as a string.
+        dictionary_item_key: String,
+    },
+    /// Lookup a dictionary item via its unique key.
+    DictionaryItem(DictionaryAddr),
+}
+
+impl DictionaryItemIdentifier {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..5) {
+            0 => DictionaryItemIdentifier::AccountNamedKey {
+                hash: rng.gen(),
+                dictionary_name: rng.random_string(32..64),
+                dictionary_item_key: rng.random_string(32..64),
+            },
+            1 => DictionaryItemIdentifier::ContractNamedKey {
+                hash: rng.gen(),
+                dictionary_name: rng.random_string(32..64),
+                dictionary_item_key: rng.random_string(32..64),
+            },
+            2 => DictionaryItemIdentifier::EntityNamedKey {
+                addr: rng.gen(),
+                dictionary_name: rng.random_string(32..64),
+                dictionary_item_key: rng.random_string(32..64),
+            },
+            3 => DictionaryItemIdentifier::URef {
+                seed_uref: rng.gen(),
+                dictionary_item_key: rng.random_string(32..64),
+            },
+            4 => DictionaryItemIdentifier::DictionaryItem(rng.gen()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl ToBytes for DictionaryItemIdentifier {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            DictionaryItemIdentifier::AccountNamedKey {
+                hash: key,
+                dictionary_name,
+                dictionary_item_key,
+            } => {
+                ACCOUNT_NAMED_KEY_TAG.write_bytes(writer)?;
+                key.write_bytes(writer)?;
+                dictionary_name.write_bytes(writer)?;
+                dictionary_item_key.write_bytes(writer)
+            }
+            DictionaryItemIdentifier::ContractNamedKey {
+                hash: key,
+                dictionary_name,
+                dictionary_item_key,
+            } => {
+                CONTRACT_NAMED_KEY_TAG.write_bytes(writer)?;
+                key.write_bytes(writer)?;
+                dictionary_name.write_bytes(writer)?;
+                dictionary_item_key.write_bytes(writer)
+            }
+            DictionaryItemIdentifier::EntityNamedKey {
+                addr,
+                dictionary_name,
+                dictionary_item_key,
+            } => {
+                ENTITY_NAMED_KEY_TAG.write_bytes(writer)?;
+                addr.write_bytes(writer)?;
+                dictionary_name.write_bytes(writer)?;
+                dictionary_item_key.write_bytes(writer)
+            }
+            DictionaryItemIdentifier::URef {
+                seed_uref,
+                dictionary_item_key,
+            } => {
+                UREF_TAG.write_bytes(writer)?;
+                seed_uref.write_bytes(writer)?;
+                dictionary_item_key.write_bytes(writer)
+            }
+            DictionaryItemIdentifier::DictionaryItem(addr) => {
+                DICTIONARY_ITEM_TAG.write_bytes(writer)?;
+                addr.write_bytes(writer)
+            }
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                DictionaryItemIdentifier::AccountNamedKey {
+                    hash,
+                    dictionary_name,
+                    dictionary_item_key,
+                } => {
+                    hash.serialized_length()
+                        + dictionary_name.serialized_length()
+                        + dictionary_item_key.serialized_length()
+                }
+                DictionaryItemIdentifier::ContractNamedKey {
+                    hash,
+                    dictionary_name,
+                    dictionary_item_key,
+                } => {
+                    hash.serialized_length()
+                        + dictionary_name.serialized_length()
+                        + dictionary_item_key.serialized_length()
+                }
+                DictionaryItemIdentifier::EntityNamedKey {
+                    addr,
+                    dictionary_name,
+                    dictionary_item_key,
+                } => {
+                    addr.serialized_length()
+                        + dictionary_name.serialized_length()
+                        + dictionary_item_key.serialized_length()
+                }
+                DictionaryItemIdentifier::URef {
+                    seed_uref,
+                    dictionary_item_key,
+                } => seed_uref.serialized_length() + dictionary_item_key.serialized_length(),
+                DictionaryItemIdentifier::DictionaryItem(addr) => addr.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for DictionaryItemIdentifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            ACCOUNT_NAMED_KEY_TAG => {
+                let (key, remainder) = FromBytes::from_bytes(remainder)?;
+                let (dictionary_name, remainder) = String::from_bytes(remainder)?;
+                let (dictionary_item_key, remainder) = String::from_bytes(remainder)?;
+                Ok((
+                    DictionaryItemIdentifier::AccountNamedKey {
+                        hash: key,
+                        dictionary_name,
+                        dictionary_item_key,
+                    },
+                    remainder,
+                ))
+            }
+            CONTRACT_NAMED_KEY_TAG => {
+                let (key, remainder) = FromBytes::from_bytes(remainder)?;
+                let (dictionary_name, remainder) = String::from_bytes(remainder)?;
+                let (dictionary_item_key, remainder) = String::from_bytes(remainder)?;
+                Ok((
+                    DictionaryItemIdentifier::ContractNamedKey {
+                        hash: key,
+                        dictionary_name,
+                        dictionary_item_key,
+                    },
+                    remainder,
+                ))
+            }
+            ENTITY_NAMED_KEY_TAG => {
+                let (addr, remainder) = FromBytes::from_bytes(remainder)?;
+                let (dictionary_name, remainder) = String::from_bytes(remainder)?;
+                let (dictionary_item_key, remainder) = String::from_bytes(remainder)?;
+                Ok((
+                    DictionaryItemIdentifier::EntityNamedKey {
+                        addr,
+                        dictionary_name,
+                        dictionary_item_key,
+                    },
+                    remainder,
+                ))
+            }
+            UREF_TAG => {
+                let (seed_uref, remainder) = FromBytes::from_bytes(remainder)?;
+                let (dictionary_item_key, remainder) = String::from_bytes(remainder)?;
+                Ok((
+                    DictionaryItemIdentifier::URef {
+                        seed_uref,
+                        dictionary_item_key,
+                    },
+                    remainder,
+                ))
+            }
+            DICTIONARY_ITEM_TAG => {
+                let (addr, remainder) = FromBytes::from_bytes(remainder)?;
+                Ok((DictionaryItemIdentifier::DictionaryItem(addr), remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = DictionaryItemIdentifier::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/entity_qualifier.rs
+++ b/binary_port/src/entity_qualifier.rs
@@ -1,0 +1,192 @@
+use crate::{DictionaryItemIdentifier, KeyPrefix, PurseIdentifier};
+#[cfg(test)]
+use casper_types::testing::TestRng;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    Key, KeyTag,
+};
+#[cfg(test)]
+use rand::Rng;
+
+const ITEM_TAG: u8 = 0;
+const ALL_ITEMS_TAG: u8 = 1;
+const DICTIONARY_ITEM_TAG: u8 = 2;
+const BALANCE_TAG: u8 = 3;
+const ITEMS_BY_PREFIX_TAG: u8 = 4;
+
+/// A request to get data from the global state.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GlobalStateEntityQualifier {
+    /// Gets an item from the global state.
+    Item {
+        /// Key under which data is stored.
+        base_key: Key,
+        /// Path under which the value is stored.
+        path: Vec<String>,
+    },
+    /// Get all items under the given key tag.
+    AllItems {
+        /// Key tag
+        key_tag: KeyTag,
+    },
+    /// Get a dictionary item by its identifier.
+    DictionaryItem {
+        /// Dictionary item identifier.
+        identifier: DictionaryItemIdentifier,
+    },
+    /// Get balance by state root and purse.
+    Balance {
+        /// Purse identifier.
+        purse_identifier: PurseIdentifier,
+    },
+    ItemsByPrefix {
+        /// Key prefix to search for.
+        key_prefix: KeyPrefix,
+    },
+}
+
+impl GlobalStateEntityQualifier {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        let gen_range = TestRng::gen_range(rng, 0..5);
+        random_for_variant(gen_range, rng)
+    }
+}
+
+#[cfg(test)]
+fn random_for_variant(gen_range: u8, rng: &mut TestRng) -> GlobalStateEntityQualifier {
+    match gen_range {
+        ITEM_TAG => {
+            let path_count = rng.gen_range(10..20);
+            GlobalStateEntityQualifier::Item {
+                base_key: rng.gen(),
+                path: std::iter::repeat_with(|| rng.random_string(32..64))
+                    .take(path_count)
+                    .collect(),
+            }
+        }
+        ALL_ITEMS_TAG => GlobalStateEntityQualifier::AllItems {
+            key_tag: KeyTag::random(rng),
+        },
+        DICTIONARY_ITEM_TAG => GlobalStateEntityQualifier::DictionaryItem {
+            identifier: DictionaryItemIdentifier::random(rng),
+        },
+        BALANCE_TAG => GlobalStateEntityQualifier::Balance {
+            purse_identifier: PurseIdentifier::random(rng),
+        },
+        ITEMS_BY_PREFIX_TAG => GlobalStateEntityQualifier::ItemsByPrefix {
+            key_prefix: KeyPrefix::random(rng),
+        },
+        _ => unreachable!(),
+    }
+}
+
+impl ToBytes for GlobalStateEntityQualifier {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            GlobalStateEntityQualifier::Item { base_key, path } => {
+                ITEM_TAG.write_bytes(writer)?;
+                base_key.write_bytes(writer)?;
+                path.write_bytes(writer)
+            }
+            GlobalStateEntityQualifier::AllItems { key_tag } => {
+                ALL_ITEMS_TAG.write_bytes(writer)?;
+                key_tag.write_bytes(writer)
+            }
+            GlobalStateEntityQualifier::DictionaryItem { identifier } => {
+                DICTIONARY_ITEM_TAG.write_bytes(writer)?;
+                identifier.write_bytes(writer)
+            }
+            GlobalStateEntityQualifier::Balance { purse_identifier } => {
+                BALANCE_TAG.write_bytes(writer)?;
+                purse_identifier.write_bytes(writer)
+            }
+            GlobalStateEntityQualifier::ItemsByPrefix { key_prefix } => {
+                ITEMS_BY_PREFIX_TAG.write_bytes(writer)?;
+                key_prefix.write_bytes(writer)
+            }
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                GlobalStateEntityQualifier::Item { base_key, path } => {
+                    base_key.serialized_length() + path.serialized_length()
+                }
+                GlobalStateEntityQualifier::AllItems { key_tag } => key_tag.serialized_length(),
+                GlobalStateEntityQualifier::DictionaryItem { identifier } => {
+                    identifier.serialized_length()
+                }
+                GlobalStateEntityQualifier::Balance { purse_identifier } => {
+                    purse_identifier.serialized_length()
+                }
+                GlobalStateEntityQualifier::ItemsByPrefix { key_prefix } => {
+                    key_prefix.serialized_length()
+                }
+            }
+    }
+}
+
+impl FromBytes for GlobalStateEntityQualifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            ITEM_TAG => {
+                let (base_key, remainder) = FromBytes::from_bytes(remainder)?;
+                let (path, remainder) = FromBytes::from_bytes(remainder)?;
+                Ok((
+                    GlobalStateEntityQualifier::Item { base_key, path },
+                    remainder,
+                ))
+            }
+            ALL_ITEMS_TAG => {
+                let (key_tag, remainder) = FromBytes::from_bytes(remainder)?;
+                Ok((GlobalStateEntityQualifier::AllItems { key_tag }, remainder))
+            }
+            DICTIONARY_ITEM_TAG => {
+                let (identifier, remainder) = FromBytes::from_bytes(remainder)?;
+                Ok((
+                    GlobalStateEntityQualifier::DictionaryItem { identifier },
+                    remainder,
+                ))
+            }
+            BALANCE_TAG => {
+                let (purse_identifier, remainder) = FromBytes::from_bytes(remainder)?;
+                Ok((
+                    GlobalStateEntityQualifier::Balance { purse_identifier },
+                    remainder,
+                ))
+            }
+            ITEMS_BY_PREFIX_TAG => {
+                let (key_prefix, remainder) = FromBytes::from_bytes(remainder)?;
+                Ok((
+                    GlobalStateEntityQualifier::ItemsByPrefix { key_prefix },
+                    remainder,
+                ))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+        for i in 0..5 {
+            let qualifier = random_for_variant(i, rng);
+            bytesrepr::test_serialization_roundtrip(&qualifier);
+        }
+    }
+}

--- a/binary_port/src/era_identifier.rs
+++ b/binary_port/src/era_identifier.rs
@@ -1,0 +1,90 @@
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    BlockIdentifier, EraId,
+};
+
+const ERA_TAG: u8 = 0;
+const BLOCK_TAG: u8 = 1;
+
+/// Identifier for an era.
+#[derive(Clone, Debug, PartialEq)]
+pub enum EraIdentifier {
+    Era(EraId),
+    Block(BlockIdentifier),
+}
+
+impl EraIdentifier {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..2) {
+            ERA_TAG => EraIdentifier::Era(EraId::random(rng)),
+            BLOCK_TAG => EraIdentifier::Block(BlockIdentifier::random(rng)),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl ToBytes for EraIdentifier {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            EraIdentifier::Era(era_id) => {
+                ERA_TAG.write_bytes(writer)?;
+                era_id.write_bytes(writer)
+            }
+            EraIdentifier::Block(block_id) => {
+                BLOCK_TAG.write_bytes(writer)?;
+                block_id.write_bytes(writer)
+            }
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                EraIdentifier::Era(era_id) => era_id.serialized_length(),
+                EraIdentifier::Block(block_id) => block_id.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for EraIdentifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            ERA_TAG => {
+                let (era_id, remainder) = EraId::from_bytes(remainder)?;
+                Ok((EraIdentifier::Era(era_id), remainder))
+            }
+            BLOCK_TAG => {
+                let (block_id, remainder) = BlockIdentifier::from_bytes(remainder)?;
+                Ok((EraIdentifier::Block(block_id), remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = EraIdentifier::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/error.rs
+++ b/binary_port/src/error.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Invalid request tag ({0})")]
+    InvalidBinaryRequestTag(u8),
+    #[error("Request too large: allowed {allowed} bytes, got {got} bytes")]
+    RequestTooLarge { allowed: u32, got: u32 },
+    #[error("Empty request")]
+    EmptyRequest,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    BytesRepr(#[from] casper_types::bytesrepr::Error),
+}

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -1,0 +1,546 @@
+use core::{convert::TryFrom, fmt};
+
+use casper_types::{InvalidDeploy, InvalidTransaction, InvalidTransactionV1};
+
+#[cfg(test)]
+use strum_macros::EnumIter;
+
+/// The error code indicating the result of handling the binary request.
+#[derive(Debug, Copy, Clone, thiserror::Error, Eq, PartialEq)]
+#[repr(u16)]
+#[cfg_attr(test, derive(EnumIter))]
+pub enum ErrorCode {
+    /// Request executed correctly.
+    #[error("request executed correctly")]
+    NoError = 0,
+    /// This function is disabled.
+    #[error("this function is disabled")]
+    FunctionDisabled = 1,
+    /// Data not found.
+    #[error("data not found")]
+    NotFound = 2,
+    /// Root not found.
+    #[error("root not found")]
+    RootNotFound = 3,
+    /// Invalid item variant.
+    #[error("invalid item variant")]
+    InvalidItemVariant = 4,
+    /// Wasm preprocessing.
+    #[error("wasm preprocessing")]
+    WasmPreprocessing = 5,
+    /// Invalid protocol version.
+    #[error("unsupported protocol version")]
+    UnsupportedProtocolVersion = 6,
+    /// Internal error.
+    #[error("internal error")]
+    InternalError = 7,
+    /// The query failed.
+    #[error("the query failed")]
+    FailedQuery = 8,
+    /// Bad request.
+    #[error("bad request")]
+    BadRequest = 9,
+    /// Received an unsupported type of request.
+    #[error("unsupported request")]
+    UnsupportedRequest = 10,
+    /// Dictionary URef not found.
+    #[error("dictionary URef not found")]
+    DictionaryURefNotFound = 11,
+    /// This node has no complete blocks.
+    #[error("no complete blocks")]
+    NoCompleteBlocks = 12,
+    /// The deploy had an invalid chain name
+    #[error("the deploy had an invalid chain name")]
+    InvalidDeployChainName = 13,
+    /// Deploy dependencies are no longer supported
+    #[error("the dependencies for this transaction are no longer supported")]
+    InvalidDeployDependenciesNoLongerSupported = 14,
+    /// The deploy sent to the network had an excessive size
+    #[error("the deploy had an excessive size")]
+    InvalidDeployExcessiveSize = 15,
+    /// The deploy sent to the network had an excessive time to live
+    #[error("the deploy had an excessive time to live")]
+    InvalidDeployExcessiveTimeToLive = 16,
+    /// The deploy sent to the network had a timestamp referencing a time that has yet to occur.
+    #[error("the deploys timestamp is in the future")]
+    InvalidDeployTimestampInFuture = 17,
+    /// The deploy sent to the network had an invalid body hash
+    #[error("the deploy had an invalid body hash")]
+    InvalidDeployBodyHash = 18,
+    /// The deploy sent to the network had an invalid deploy hash i.e. the provided deploy hash
+    /// didn't match the derived deploy hash
+    #[error("the deploy had an invalid deploy hash")]
+    InvalidDeployHash = 19,
+    /// The deploy sent to the network had an empty approval set
+    #[error("the deploy had no approvals")]
+    InvalidDeployEmptyApprovals = 20,
+    /// The deploy sent to the network had an invalid approval
+    #[error("the deploy had an invalid approval")]
+    InvalidDeployApproval = 21,
+    /// The deploy sent to the network had an excessive session args length
+    #[error("the deploy had an excessive session args length")]
+    InvalidDeployExcessiveSessionArgsLength = 22,
+    /// The deploy sent to the network had an excessive payment args length
+    #[error("the deploy had an excessive payment args length")]
+    InvalidDeployExcessivePaymentArgsLength = 23,
+    /// The deploy sent to the network had a missing payment amount
+    #[error("the deploy had a missing payment amount")]
+    InvalidDeployMissingPaymentAmount = 24,
+    /// The deploy sent to the network had a payment amount that was not parseable
+    #[error("the deploy sent to the network had a payment amount that was unable to be parsed")]
+    InvalidDeployFailedToParsePaymentAmount = 25,
+    /// The deploy sent to the network exceeded the block gas limit
+    #[error("the deploy sent to the network exceeded the block gas limit")]
+    InvalidDeployExceededBlockGasLimit = 26,
+    /// The deploy sent to the network was missing a transfer amount
+    #[error("the deploy sent to the network was missing a transfer amount")]
+    InvalidDeployMissingTransferAmount = 27,
+    /// The deploy sent to the network had a transfer amount that was unable to be parseable
+    #[error("the deploy sent to the network had a transfer amount that was unable to be parsed")]
+    InvalidDeployFailedToParseTransferAmount = 28,
+    /// The deploy sent to the network had a transfer amount that was insufficient
+    #[error("the deploy sent to the network had an insufficient transfer amount")]
+    InvalidDeployInsufficientTransferAmount = 29,
+    /// The deploy sent to the network had excessive approvals
+    #[error("the deploy sent to the network had excessive approvals")]
+    InvalidDeployExcessiveApprovals = 30,
+    /// The network was unable to calculate the gas limit for the deploy
+    #[error("the network was unable to calculate the gas limit associated with the deploy")]
+    InvalidDeployUnableToCalculateGasLimit = 31,
+    /// The network was unable to calculate the gas cost for the deploy
+    #[error("the network was unable to calculate the gas cost for the deploy")]
+    InvalidDeployUnableToCalculateGasCost = 32,
+    /// The deploy sent to the network was invalid for an unspecified reason
+    #[error("the deploy sent to the network was invalid for an unspecified reason")]
+    InvalidDeployUnspecified = 33,
+    /// The transaction sent to the network had an invalid chain name
+    #[error("the transaction sent to the network had an invalid chain name")]
+    InvalidTransactionChainName = 34,
+    /// The transaction sent to the network had an excessive size
+    #[error("the transaction sent to the network had an excessive size")]
+    InvalidTransactionExcessiveSize = 35,
+    /// The transaction sent to the network had an excessive time to live
+    #[error("the transaction sent to the network had an excessive time to live")]
+    InvalidTransactionExcessiveTimeToLive = 36,
+    /// The transaction sent to the network had a timestamp located in the future.
+    #[error("the transaction sent to the network had a timestamp that has not yet occurred")]
+    InvalidTransactionTimestampInFuture = 37,
+    /// The transaction sent to the network had a provided body hash that conflicted with hash
+    /// derived by the network
+    #[error("the transaction sent to the network had an invalid body hash")]
+    InvalidTransactionBodyHash = 38,
+    /// The transaction sent to the network had a provided hash that conflicted with the hash
+    /// derived by the network
+    #[error("the transaction sent to the network had an invalid hash")]
+    InvalidTransactionHash = 39,
+    /// The transaction sent to the network had an empty approvals set
+    #[error("the transaction sent to the network had no approvals")]
+    InvalidTransactionEmptyApprovals = 40,
+    /// The transaction sent to the network had an invalid approval
+    #[error("the transaction sent to the network had an invalid approval")]
+    InvalidTransactionInvalidApproval = 41,
+    /// The transaction sent to the network had excessive args length
+    #[error("the transaction sent to the network had excessive args length")]
+    InvalidTransactionExcessiveArgsLength = 42,
+    /// The transaction sent to the network had excessive approvals
+    #[error("the transaction sent to the network had excessive approvals")]
+    InvalidTransactionExcessiveApprovals = 43,
+    /// The transaction sent to the network exceeds the block gas limit
+    #[error("the transaction sent to the network exceeds the networks block gas limit")]
+    InvalidTransactionExceedsBlockGasLimit = 44,
+    /// The transaction sent to the network had a missing arg
+    #[error("the transaction sent to the network was missing an argument")]
+    InvalidTransactionMissingArg = 45,
+    /// The transaction sent to the network had an argument with an unexpected type
+    #[error("the transaction sent to the network had an unexpected argument type")]
+    InvalidTransactionUnexpectedArgType = 46,
+    /// The transaction sent to the network had an invalid argument
+    #[error("the transaction sent to the network had an invalid argument")]
+    InvalidTransactionInvalidArg = 47,
+    /// The transaction sent to the network had an insufficient transfer amount
+    #[error("the transaction sent to the network had an insufficient transfer amount")]
+    InvalidTransactionInsufficientTransferAmount = 48,
+    /// The transaction sent to the network had a custom entry point when it should have a non
+    /// custom entry point.
+    #[error("the native transaction sent to the network should not have a custom entry point")]
+    InvalidTransactionEntryPointCannotBeCustom = 49,
+    /// The transaction sent to the network had a standard entry point when it must be custom.
+    #[error("the non-native transaction sent to the network must have a custom entry point")]
+    InvalidTransactionEntryPointMustBeCustom = 50,
+    /// The transaction sent to the network had empty module bytes
+    #[error("the transaction sent to the network had empty module bytes")]
+    InvalidTransactionEmptyModuleBytes = 51,
+    /// The transaction sent to the network had an invalid gas price conversion
+    #[error("the transaction sent to the network had an invalid gas price conversion")]
+    InvalidTransactionGasPriceConversion = 52,
+    /// The network was unable to calculate the gas limit for the transaction sent.
+    #[error("the network was unable to calculate the gas limit for the transaction sent")]
+    InvalidTransactionUnableToCalculateGasLimit = 53,
+    /// The network was unable to calculate the gas cost for the transaction sent.
+    #[error("the network was unable to calculate the gas cost for the transaction sent.")]
+    InvalidTransactionUnableToCalculateGasCost = 54,
+    /// The transaction sent to the network had an invalid pricing mode
+    #[error("the transaction sent to the network had an invalid pricing mode")]
+    InvalidTransactionPricingMode = 55,
+    /// The transaction sent to the network was invalid for an unspecified reason
+    #[error("the transaction sent to the network was invalid for an unspecified reason")]
+    InvalidTransactionUnspecified = 56,
+    /// As the various enums are tagged non_exhaustive, it is possible that in the future none of
+    /// these previous errors cover the error that occurred, therefore we need some catchall in
+    /// the case that nothing else works.
+    #[error("the transaction or deploy sent to the network was invalid for an unspecified reason")]
+    InvalidTransactionOrDeployUnspecified = 57,
+    /// The switch block for the requested era was not found
+    #[error("the switch block for the requested era was not found")]
+    SwitchBlockNotFound = 58,
+    #[error("the parent of the switch block for the requested era was not found")]
+    /// The parent of the switch block for the requested era was not found
+    SwitchBlockParentNotFound = 59,
+    #[error("cannot serve rewards stored in V1 format")]
+    /// Cannot serve rewards stored in V1 format
+    UnsupportedRewardsV1Request = 60,
+    /// Invalid binary port version.
+    #[error("binary protocol version mismatch")]
+    BinaryProtocolVersionMismatch = 61,
+    /// Blockchain is empty
+    #[error("blockchain is empty")]
+    EmptyBlockchain = 62,
+    /// Expected deploy, but got transaction
+    #[error("expected deploy, got transaction")]
+    ExpectedDeploy = 63,
+    /// Expected transaction, but got deploy
+    #[error("expected transaction V1, got deploy")]
+    ExpectedTransaction = 64,
+    /// Transaction has expired
+    #[error("transaction has expired")]
+    TransactionExpired = 65,
+    /// Transactions parameters are missing or incorrect
+    #[error("missing or incorrect transaction parameters")]
+    MissingOrIncorrectParameters = 66,
+    /// No such addressable entity
+    #[error("no such addressable entity")]
+    NoSuchAddressableEntity = 67,
+    // No such contract at hash
+    #[error("no such contract at hash")]
+    NoSuchContractAtHash = 68,
+    /// No such entry point
+    #[error("no such entry point")]
+    NoSuchEntryPoint = 69,
+    /// No such package at hash
+    #[error("no such package at hash")]
+    NoSuchPackageAtHash = 70,
+    /// Invalid entity at version
+    #[error("invalid entity at version")]
+    InvalidEntityAtVersion = 71,
+    /// Disabled entity at version
+    #[error("disabled entity at version")]
+    DisabledEntityAtVersion = 72,
+    /// Missing entity at version
+    #[error("missing entity at version")]
+    MissingEntityAtVersion = 73,
+    /// Invalid associated keys
+    #[error("invalid associated keys")]
+    InvalidAssociatedKeys = 74,
+    /// Insufficient signature weight
+    #[error("insufficient signature weight")]
+    InsufficientSignatureWeight = 75,
+    /// Insufficient balance
+    #[error("insufficient balance")]
+    InsufficientBalance = 76,
+    /// Unknown balance
+    #[error("unknown balance")]
+    UnknownBalance = 77,
+    /// Invalid payment variant for deploy
+    #[error("invalid payment variant for deploy")]
+    DeployInvalidPaymentVariant = 78,
+    /// Missing payment amount for deploy
+    #[error("missing payment amount for deploy")]
+    DeployMissingPaymentAmount = 79,
+    /// Failed to parse payment amount for deploy
+    #[error("failed to parse payment amount for deploy")]
+    DeployFailedToParsePaymentAmount = 80,
+    /// Missing transfer target for deploy
+    #[error("missing transfer target for deploy")]
+    DeployMissingTransferTarget = 81,
+    /// Missing module bytes for deploy
+    #[error("missing module bytes for deploy")]
+    DeployMissingModuleBytes = 82,
+    /// Entry point cannot be 'call'
+    #[error("entry point cannot be 'call'")]
+    InvalidTransactionEntryPointCannotBeCall = 83,
+    /// Invalid transaction kind
+    #[error("invalid transaction kind")]
+    InvalidTransactionInvalidTransactionKind = 84,
+    /// Gas price tolerance too low
+    #[error("gas price tolerance too low")]
+    GasPriceToleranceTooLow = 85,
+    /// Received V1 Transaction for spec exec.
+    #[error("received v1 transaction for speculative execution")]
+    ReceivedV1Transaction = 86,
+    /// Purse was not found for given identifier.
+    #[error("purse was not found for given identifier")]
+    PurseNotFound = 87,
+    /// Too many requests per second.
+    #[error("request was throttled")]
+    RequestThrottled = 88,
+}
+
+impl TryFrom<u16> for ErrorCode {
+    type Error = UnknownErrorCode;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(ErrorCode::NoError),
+            1 => Ok(ErrorCode::FunctionDisabled),
+            2 => Ok(ErrorCode::NotFound),
+            3 => Ok(ErrorCode::RootNotFound),
+            4 => Ok(ErrorCode::InvalidItemVariant),
+            5 => Ok(ErrorCode::WasmPreprocessing),
+            6 => Ok(ErrorCode::UnsupportedProtocolVersion),
+            7 => Ok(ErrorCode::InternalError),
+            8 => Ok(ErrorCode::FailedQuery),
+            9 => Ok(ErrorCode::BadRequest),
+            10 => Ok(ErrorCode::UnsupportedRequest),
+            11 => Ok(ErrorCode::DictionaryURefNotFound),
+            12 => Ok(ErrorCode::NoCompleteBlocks),
+            13 => Ok(ErrorCode::InvalidDeployChainName),
+            14 => Ok(ErrorCode::InvalidDeployDependenciesNoLongerSupported),
+            15 => Ok(ErrorCode::InvalidDeployExcessiveSize),
+            16 => Ok(ErrorCode::InvalidDeployExcessiveTimeToLive),
+            17 => Ok(ErrorCode::InvalidDeployTimestampInFuture),
+            18 => Ok(ErrorCode::InvalidDeployBodyHash),
+            19 => Ok(ErrorCode::InvalidDeployHash),
+            20 => Ok(ErrorCode::InvalidDeployEmptyApprovals),
+            21 => Ok(ErrorCode::InvalidDeployApproval),
+            22 => Ok(ErrorCode::InvalidDeployExcessiveSessionArgsLength),
+            23 => Ok(ErrorCode::InvalidDeployExcessivePaymentArgsLength),
+            24 => Ok(ErrorCode::InvalidDeployMissingPaymentAmount),
+            25 => Ok(ErrorCode::InvalidDeployFailedToParsePaymentAmount),
+            26 => Ok(ErrorCode::InvalidDeployExceededBlockGasLimit),
+            27 => Ok(ErrorCode::InvalidDeployMissingTransferAmount),
+            28 => Ok(ErrorCode::InvalidDeployFailedToParseTransferAmount),
+            29 => Ok(ErrorCode::InvalidDeployInsufficientTransferAmount),
+            30 => Ok(ErrorCode::InvalidDeployExcessiveApprovals),
+            31 => Ok(ErrorCode::InvalidDeployUnableToCalculateGasLimit),
+            32 => Ok(ErrorCode::InvalidDeployUnableToCalculateGasCost),
+            33 => Ok(ErrorCode::InvalidDeployUnspecified),
+            34 => Ok(ErrorCode::InvalidTransactionChainName),
+            35 => Ok(ErrorCode::InvalidTransactionExcessiveSize),
+            36 => Ok(ErrorCode::InvalidTransactionExcessiveTimeToLive),
+            37 => Ok(ErrorCode::InvalidTransactionTimestampInFuture),
+            38 => Ok(ErrorCode::InvalidTransactionBodyHash),
+            39 => Ok(ErrorCode::InvalidTransactionHash),
+            40 => Ok(ErrorCode::InvalidTransactionEmptyApprovals),
+            41 => Ok(ErrorCode::InvalidTransactionInvalidApproval),
+            42 => Ok(ErrorCode::InvalidTransactionExcessiveArgsLength),
+            43 => Ok(ErrorCode::InvalidTransactionExcessiveApprovals),
+            44 => Ok(ErrorCode::InvalidTransactionExceedsBlockGasLimit),
+            45 => Ok(ErrorCode::InvalidTransactionMissingArg),
+            46 => Ok(ErrorCode::InvalidTransactionUnexpectedArgType),
+            47 => Ok(ErrorCode::InvalidTransactionInvalidArg),
+            48 => Ok(ErrorCode::InvalidTransactionInsufficientTransferAmount),
+            49 => Ok(ErrorCode::InvalidTransactionEntryPointCannotBeCustom),
+            50 => Ok(ErrorCode::InvalidTransactionEntryPointMustBeCustom),
+            51 => Ok(ErrorCode::InvalidTransactionEmptyModuleBytes),
+            52 => Ok(ErrorCode::InvalidTransactionGasPriceConversion),
+            53 => Ok(ErrorCode::InvalidTransactionUnableToCalculateGasLimit),
+            54 => Ok(ErrorCode::InvalidTransactionUnableToCalculateGasCost),
+            55 => Ok(ErrorCode::InvalidTransactionPricingMode),
+            56 => Ok(ErrorCode::InvalidTransactionUnspecified),
+            57 => Ok(ErrorCode::InvalidTransactionOrDeployUnspecified),
+            58 => Ok(ErrorCode::SwitchBlockNotFound),
+            59 => Ok(ErrorCode::SwitchBlockParentNotFound),
+            60 => Ok(ErrorCode::UnsupportedRewardsV1Request),
+            61 => Ok(ErrorCode::BinaryProtocolVersionMismatch),
+            62 => Ok(ErrorCode::EmptyBlockchain),
+            63 => Ok(ErrorCode::ExpectedDeploy),
+            64 => Ok(ErrorCode::ExpectedTransaction),
+            65 => Ok(ErrorCode::TransactionExpired),
+            66 => Ok(ErrorCode::MissingOrIncorrectParameters),
+            67 => Ok(ErrorCode::NoSuchAddressableEntity),
+            68 => Ok(ErrorCode::NoSuchContractAtHash),
+            69 => Ok(ErrorCode::NoSuchEntryPoint),
+            70 => Ok(ErrorCode::NoSuchPackageAtHash),
+            71 => Ok(ErrorCode::InvalidEntityAtVersion),
+            72 => Ok(ErrorCode::DisabledEntityAtVersion),
+            73 => Ok(ErrorCode::MissingEntityAtVersion),
+            74 => Ok(ErrorCode::InvalidAssociatedKeys),
+            75 => Ok(ErrorCode::InsufficientSignatureWeight),
+            76 => Ok(ErrorCode::InsufficientBalance),
+            77 => Ok(ErrorCode::UnknownBalance),
+            78 => Ok(ErrorCode::DeployInvalidPaymentVariant),
+            79 => Ok(ErrorCode::DeployMissingPaymentAmount),
+            80 => Ok(ErrorCode::DeployFailedToParsePaymentAmount),
+            81 => Ok(ErrorCode::DeployMissingTransferTarget),
+            82 => Ok(ErrorCode::DeployMissingModuleBytes),
+            83 => Ok(ErrorCode::InvalidTransactionEntryPointCannotBeCall),
+            84 => Ok(ErrorCode::InvalidTransactionInvalidTransactionKind),
+            85 => Ok(ErrorCode::GasPriceToleranceTooLow),
+            86 => Ok(ErrorCode::ReceivedV1Transaction),
+            87 => Ok(ErrorCode::PurseNotFound),
+            88 => Ok(ErrorCode::RequestThrottled),
+            _ => Err(UnknownErrorCode),
+        }
+    }
+}
+
+/// Error indicating that the error code is unknown.
+#[derive(Debug, Clone, Copy)]
+pub struct UnknownErrorCode;
+
+impl fmt::Display for UnknownErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown node error code")
+    }
+}
+
+impl std::error::Error for UnknownErrorCode {}
+
+impl From<InvalidTransaction> for ErrorCode {
+    fn from(value: InvalidTransaction) -> Self {
+        match value {
+            InvalidTransaction::Deploy(invalid_deploy) => ErrorCode::from(invalid_deploy),
+            InvalidTransaction::V1(invalid_transaction) => ErrorCode::from(invalid_transaction),
+            _ => ErrorCode::InvalidTransactionOrDeployUnspecified,
+        }
+    }
+}
+
+impl From<InvalidDeploy> for ErrorCode {
+    fn from(value: InvalidDeploy) -> Self {
+        match value {
+            InvalidDeploy::InvalidChainName { .. } => ErrorCode::InvalidDeployChainName,
+            InvalidDeploy::DependenciesNoLongerSupported => {
+                ErrorCode::InvalidDeployDependenciesNoLongerSupported
+            }
+            InvalidDeploy::ExcessiveSize(_) => ErrorCode::InvalidDeployExcessiveSize,
+            InvalidDeploy::ExcessiveTimeToLive { .. } => {
+                ErrorCode::InvalidDeployExcessiveTimeToLive
+            }
+            InvalidDeploy::TimestampInFuture { .. } => ErrorCode::InvalidDeployTimestampInFuture,
+            InvalidDeploy::InvalidBodyHash => ErrorCode::InvalidDeployBodyHash,
+            InvalidDeploy::InvalidDeployHash => ErrorCode::InvalidDeployHash,
+            InvalidDeploy::EmptyApprovals => ErrorCode::InvalidDeployEmptyApprovals,
+            InvalidDeploy::InvalidApproval { .. } => ErrorCode::InvalidDeployApproval,
+            InvalidDeploy::ExcessiveSessionArgsLength { .. } => {
+                ErrorCode::InvalidDeployExcessiveSessionArgsLength
+            }
+            InvalidDeploy::ExcessivePaymentArgsLength { .. } => {
+                ErrorCode::InvalidDeployExcessivePaymentArgsLength
+            }
+            InvalidDeploy::MissingPaymentAmount => ErrorCode::InvalidDeployMissingPaymentAmount,
+            InvalidDeploy::FailedToParsePaymentAmount => {
+                ErrorCode::InvalidDeployFailedToParsePaymentAmount
+            }
+            InvalidDeploy::ExceededBlockGasLimit { .. } => {
+                ErrorCode::InvalidDeployExceededBlockGasLimit
+            }
+            InvalidDeploy::MissingTransferAmount => ErrorCode::InvalidDeployMissingTransferAmount,
+            InvalidDeploy::FailedToParseTransferAmount => {
+                ErrorCode::InvalidDeployFailedToParseTransferAmount
+            }
+            InvalidDeploy::InsufficientTransferAmount { .. } => {
+                ErrorCode::InvalidDeployInsufficientTransferAmount
+            }
+            InvalidDeploy::ExcessiveApprovals { .. } => ErrorCode::InvalidDeployExcessiveApprovals,
+            InvalidDeploy::UnableToCalculateGasLimit => {
+                ErrorCode::InvalidDeployUnableToCalculateGasLimit
+            }
+            InvalidDeploy::UnableToCalculateGasCost => {
+                ErrorCode::InvalidDeployUnableToCalculateGasCost
+            }
+            InvalidDeploy::GasPriceToleranceTooLow { .. } => ErrorCode::GasPriceToleranceTooLow,
+            _ => ErrorCode::InvalidDeployUnspecified,
+        }
+    }
+}
+
+impl From<InvalidTransactionV1> for ErrorCode {
+    fn from(value: InvalidTransactionV1) -> Self {
+        match value {
+            InvalidTransactionV1::InvalidChainName { .. } => ErrorCode::InvalidTransactionChainName,
+            InvalidTransactionV1::ExcessiveSize(_) => ErrorCode::InvalidTransactionExcessiveSize,
+            InvalidTransactionV1::ExcessiveTimeToLive { .. } => {
+                ErrorCode::InvalidTransactionExcessiveTimeToLive
+            }
+            InvalidTransactionV1::TimestampInFuture { .. } => {
+                ErrorCode::InvalidTransactionTimestampInFuture
+            }
+            InvalidTransactionV1::InvalidBodyHash => ErrorCode::InvalidTransactionBodyHash,
+            InvalidTransactionV1::InvalidTransactionHash => ErrorCode::InvalidTransactionHash,
+            InvalidTransactionV1::EmptyApprovals => ErrorCode::InvalidTransactionEmptyApprovals,
+            InvalidTransactionV1::InvalidApproval { .. } => {
+                ErrorCode::InvalidTransactionInvalidApproval
+            }
+            InvalidTransactionV1::ExcessiveArgsLength { .. } => {
+                ErrorCode::InvalidTransactionExcessiveArgsLength
+            }
+            InvalidTransactionV1::ExcessiveApprovals { .. } => {
+                ErrorCode::InvalidTransactionExcessiveApprovals
+            }
+            InvalidTransactionV1::ExceedsBlockGasLimit { .. } => {
+                ErrorCode::InvalidTransactionExceedsBlockGasLimit
+            }
+            InvalidTransactionV1::MissingArg { .. } => ErrorCode::InvalidTransactionMissingArg,
+            InvalidTransactionV1::UnexpectedArgType { .. } => {
+                ErrorCode::InvalidTransactionUnexpectedArgType
+            }
+            InvalidTransactionV1::InvalidArg { .. } => ErrorCode::InvalidTransactionInvalidArg,
+            InvalidTransactionV1::InsufficientTransferAmount { .. } => {
+                ErrorCode::InvalidTransactionInsufficientTransferAmount
+            }
+            InvalidTransactionV1::EntryPointCannotBeCustom { .. } => {
+                ErrorCode::InvalidTransactionEntryPointCannotBeCustom
+            }
+            InvalidTransactionV1::EntryPointMustBeCustom { .. } => {
+                ErrorCode::InvalidTransactionEntryPointMustBeCustom
+            }
+            InvalidTransactionV1::EmptyModuleBytes => ErrorCode::InvalidTransactionEmptyModuleBytes,
+            InvalidTransactionV1::GasPriceConversion { .. } => {
+                ErrorCode::InvalidTransactionGasPriceConversion
+            }
+            InvalidTransactionV1::UnableToCalculateGasLimit => {
+                ErrorCode::InvalidTransactionUnableToCalculateGasLimit
+            }
+            InvalidTransactionV1::UnableToCalculateGasCost => {
+                ErrorCode::InvalidTransactionUnableToCalculateGasCost
+            }
+            InvalidTransactionV1::InvalidPricingMode { .. } => {
+                ErrorCode::InvalidTransactionPricingMode
+            }
+            InvalidTransactionV1::EntryPointCannotBeCall => {
+                ErrorCode::InvalidTransactionEntryPointCannotBeCall
+            }
+            InvalidTransactionV1::InvalidTransactionLane(_) => {
+                ErrorCode::InvalidTransactionInvalidTransactionKind
+            }
+            InvalidTransactionV1::GasPriceToleranceTooLow { .. } => {
+                ErrorCode::GasPriceToleranceTooLow
+            }
+            _ => ErrorCode::InvalidTransactionUnspecified,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use strum::IntoEnumIterator;
+
+    use crate::ErrorCode;
+
+    #[test]
+    fn try_from_decoded_all_variants() {
+        for variant in ErrorCode::iter() {
+            let as_int = variant as u16;
+            let decoded = ErrorCode::try_from(as_int);
+            assert!(
+                decoded.is_ok(),
+                "variant {} not covered by TryFrom<u16> implementation",
+                as_int
+            );
+            assert_eq!(decoded.unwrap(), variant);
+        }
+    }
+}

--- a/binary_port/src/get_request.rs
+++ b/binary_port/src/get_request.rs
@@ -1,0 +1,165 @@
+use casper_types::{
+    bytesrepr::{self, Bytes, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    Digest,
+};
+
+use crate::GlobalStateRequest;
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+const RECORD_TAG: u8 = 0;
+const INFORMATION_TAG: u8 = 1;
+const STATE_TAG: u8 = 2;
+const TRIE_TAG: u8 = 3;
+
+/// A request to get data from the node.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GetRequest {
+    /// Retrieves a record from the node.
+    Record {
+        /// Type tag of the record to retrieve.
+        record_type_tag: u16,
+        /// Key encoded into bytes.
+        key: Vec<u8>,
+    },
+    /// Retrieves information from the node.
+    Information {
+        /// Type tag of the information to retrieve.
+        info_type_tag: u16,
+        /// Key encoded into bytes.
+        key: Vec<u8>,
+    },
+    /// Retrieves data from the global state.
+    State(Box<GlobalStateRequest>),
+    /// Get a trie by its Digest.
+    Trie {
+        /// A trie key.
+        trie_key: Digest,
+    },
+}
+
+impl GetRequest {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..4) {
+            0 => GetRequest::Record {
+                record_type_tag: rng.gen(),
+                key: rng.random_vec(16..32),
+            },
+            1 => GetRequest::Information {
+                info_type_tag: rng.gen(),
+                key: rng.random_vec(16..32),
+            },
+            2 => GetRequest::State(Box::new(GlobalStateRequest::random(rng))),
+            3 => GetRequest::Trie {
+                trie_key: Digest::random(rng),
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl ToBytes for GetRequest {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            GetRequest::Record {
+                record_type_tag,
+                key,
+            } => {
+                RECORD_TAG.write_bytes(writer)?;
+                record_type_tag.write_bytes(writer)?;
+                key.write_bytes(writer)
+            }
+            GetRequest::Information { info_type_tag, key } => {
+                INFORMATION_TAG.write_bytes(writer)?;
+                info_type_tag.write_bytes(writer)?;
+                key.write_bytes(writer)
+            }
+            GetRequest::State(req) => {
+                STATE_TAG.write_bytes(writer)?;
+                req.write_bytes(writer)
+            }
+            GetRequest::Trie { trie_key } => {
+                TRIE_TAG.write_bytes(writer)?;
+                trie_key.write_bytes(writer)
+            }
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                GetRequest::Record {
+                    record_type_tag,
+                    key,
+                } => record_type_tag.serialized_length() + key.serialized_length(),
+                GetRequest::Information { info_type_tag, key } => {
+                    info_type_tag.serialized_length() + key.serialized_length()
+                }
+                GetRequest::State(req) => req.serialized_length(),
+                GetRequest::Trie { trie_key } => trie_key.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for GetRequest {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = FromBytes::from_bytes(bytes)?;
+        match tag {
+            RECORD_TAG => {
+                let (record_type_tag, remainder) = FromBytes::from_bytes(remainder)?;
+                let (key, remainder) = Bytes::from_bytes(remainder)?;
+                Ok((
+                    GetRequest::Record {
+                        record_type_tag,
+                        key: key.into(),
+                    },
+                    remainder,
+                ))
+            }
+            INFORMATION_TAG => {
+                let (info_type_tag, remainder) = FromBytes::from_bytes(remainder)?;
+                let (key, remainder) = Bytes::from_bytes(remainder)?;
+                Ok((
+                    GetRequest::Information {
+                        info_type_tag,
+                        key: key.into(),
+                    },
+                    remainder,
+                ))
+            }
+            STATE_TAG => {
+                let (req, remainder) = FromBytes::from_bytes(remainder)?;
+                Ok((GetRequest::State(Box::new(req)), remainder))
+            }
+            TRIE_TAG => {
+                let (trie_key, remainder) = FromBytes::from_bytes(remainder)?;
+                Ok((GetRequest::Trie { trie_key }, remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = GetRequest::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/global_state_query_result.rs
+++ b/binary_port/src/global_state_query_result.rs
@@ -1,0 +1,119 @@
+//! The result of the query for the global state value.
+
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    global_state::TrieMerkleProof,
+    Key, StoredValue,
+};
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+
+#[cfg(test)]
+use casper_types::{ByteCode, ByteCodeKind};
+use serde::Serialize;
+
+/// Carries the successful result of the global state query.
+#[derive(Debug, PartialEq, Clone, Serialize)]
+pub struct GlobalStateQueryResult {
+    /// Stored value.
+    value: StoredValue,
+    /// Proof.
+    merkle_proof: Vec<TrieMerkleProof<Key, StoredValue>>,
+}
+
+impl GlobalStateQueryResult {
+    /// Creates the global state query result.
+    pub fn new(value: StoredValue, merkle_proof: Vec<TrieMerkleProof<Key, StoredValue>>) -> Self {
+        Self {
+            value,
+            merkle_proof,
+        }
+    }
+
+    /// Returns the stored value.
+    pub fn value(&self) -> &StoredValue {
+        &self.value
+    }
+
+    /// Returns the stored value and the merkle proof.
+    pub fn into_inner(self) -> (StoredValue, Vec<TrieMerkleProof<Key, StoredValue>>) {
+        (self.value, self.merkle_proof)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random_invalid(rng: &mut TestRng) -> Self {
+        use casper_types::{global_state::TrieMerkleProofStep, CLValue};
+        use rand::Rng;
+        // Note: This does NOT create a logically-valid struct. Instance created by this function
+        // should be used in `bytesrepr` tests only.
+
+        let mut merkle_proof = vec![];
+        for _ in 0..rng.gen_range(0..10) {
+            let stored_value = StoredValue::CLValue(
+                CLValue::from_t(rng.gen::<i32>()).expect("should create CLValue"),
+            );
+            let steps = (0..rng.gen_range(0..10))
+                .map(|_| TrieMerkleProofStep::random(rng))
+                .collect();
+            merkle_proof.push(TrieMerkleProof::new(rng.gen(), stored_value, steps));
+        }
+
+        Self {
+            value: StoredValue::ByteCode(ByteCode::new(
+                ByteCodeKind::V1CasperWasm,
+                rng.random_vec(10..20),
+            )),
+            merkle_proof,
+        }
+    }
+}
+
+impl ToBytes for GlobalStateQueryResult {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let GlobalStateQueryResult {
+            value,
+            merkle_proof,
+        } = self;
+        value.write_bytes(writer)?;
+        merkle_proof.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.value.serialized_length() + self.merkle_proof.serialized_length()
+    }
+}
+
+impl FromBytes for GlobalStateQueryResult {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (value, remainder) = FromBytes::from_bytes(bytes)?;
+        let (merkle_proof, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((
+            GlobalStateQueryResult {
+                value,
+                merkle_proof,
+            },
+            remainder,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = GlobalStateQueryResult::random_invalid(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/information_request.rs
+++ b/binary_port/src/information_request.rs
@@ -1,0 +1,702 @@
+use core::convert::TryFrom;
+
+#[cfg(test)]
+use rand::Rng;
+
+use crate::{get_request::GetRequest, EraIdentifier};
+#[cfg(test)]
+use casper_types::testing::TestRng;
+use casper_types::{
+    account::AccountHash,
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    contracts::{ContractHash, ContractPackageHash},
+    BlockIdentifier, EntityAddr, GlobalStateIdentifier, PackageAddr, PublicKey, TransactionHash,
+};
+
+/// Request for information from the node.
+#[derive(Clone, Debug, PartialEq)]
+pub enum InformationRequest {
+    /// Returns the block header by an identifier, no identifier indicates the latest block.
+    BlockHeader(Option<BlockIdentifier>),
+    /// Returns the signed block by an identifier, no identifier indicates the latest block.
+    SignedBlock(Option<BlockIdentifier>),
+    /// Returns a transaction with approvals and execution info for a given hash.
+    Transaction {
+        /// Hash of the transaction to retrieve.
+        hash: TransactionHash,
+        /// Whether to return the deploy with the finalized approvals substituted.
+        with_finalized_approvals: bool,
+    },
+    /// Returns connected peers.
+    Peers,
+    /// Returns node uptime.
+    Uptime,
+    /// Returns last progress of the sync process.
+    LastProgress,
+    /// Returns current state of the main reactor.
+    ReactorState,
+    /// Returns network name.
+    NetworkName,
+    /// Returns consensus validator changes.
+    ConsensusValidatorChanges,
+    /// Returns status of the BlockSynchronizer.
+    BlockSynchronizerStatus,
+    /// Returns the available block range.
+    AvailableBlockRange,
+    /// Returns info about next upgrade.
+    NextUpgrade,
+    /// Returns consensus status.
+    ConsensusStatus,
+    /// Returns chainspec raw bytes.
+    ChainspecRawBytes,
+    /// Returns the status information of the node.
+    NodeStatus,
+    /// Returns the latest switch block header.
+    LatestSwitchBlockHeader,
+    /// Returns the reward for a validator or a delegator in a specific era.
+    Reward {
+        /// Identifier of the era to get the reward for. Must point to either a switch block or
+        /// a valid `EraId`. If `None`, the reward for the latest switch block is returned.
+        era_identifier: Option<EraIdentifier>,
+        /// Public key of the validator to get the reward for.
+        validator: Box<PublicKey>,
+        /// Public key of the delegator to get the reward for.
+        /// If `None`, the reward for the validator is returned.
+        delegator: Option<Box<PublicKey>>,
+    },
+    /// Returns the current Casper protocol version.
+    ProtocolVersion,
+    /// Returns the contract package by an identifier.
+    Package {
+        /// Global state identifier, `None` means "latest block state".
+        state_identifier: Option<GlobalStateIdentifier>,
+        /// Identifier of the contract package to retrieve.
+        identifier: PackageIdentifier,
+    },
+    /// Returns the entity by an identifier.
+    Entity {
+        /// Global state identifier, `None` means "latest block state".
+        state_identifier: Option<GlobalStateIdentifier>,
+        /// Identifier of the entity to retrieve.
+        identifier: EntityIdentifier,
+        /// Whether to return the bytecode with the entity.
+        include_bytecode: bool,
+    },
+}
+
+impl InformationRequest {
+    /// Returns the tag of the request.
+    pub fn tag(&self) -> InformationRequestTag {
+        match self {
+            InformationRequest::BlockHeader(_) => InformationRequestTag::BlockHeader,
+            InformationRequest::SignedBlock(_) => InformationRequestTag::SignedBlock,
+            InformationRequest::Transaction { .. } => InformationRequestTag::Transaction,
+            InformationRequest::Peers => InformationRequestTag::Peers,
+            InformationRequest::Uptime => InformationRequestTag::Uptime,
+            InformationRequest::LastProgress => InformationRequestTag::LastProgress,
+            InformationRequest::ReactorState => InformationRequestTag::ReactorState,
+            InformationRequest::NetworkName => InformationRequestTag::NetworkName,
+            InformationRequest::ConsensusValidatorChanges => {
+                InformationRequestTag::ConsensusValidatorChanges
+            }
+            InformationRequest::BlockSynchronizerStatus => {
+                InformationRequestTag::BlockSynchronizerStatus
+            }
+            InformationRequest::AvailableBlockRange => InformationRequestTag::AvailableBlockRange,
+            InformationRequest::NextUpgrade => InformationRequestTag::NextUpgrade,
+            InformationRequest::ConsensusStatus => InformationRequestTag::ConsensusStatus,
+            InformationRequest::ChainspecRawBytes => InformationRequestTag::ChainspecRawBytes,
+            InformationRequest::NodeStatus => InformationRequestTag::NodeStatus,
+            InformationRequest::LatestSwitchBlockHeader => {
+                InformationRequestTag::LatestSwitchBlockHeader
+            }
+            InformationRequest::Reward { .. } => InformationRequestTag::Reward,
+            InformationRequest::ProtocolVersion => InformationRequestTag::ProtocolVersion,
+            InformationRequest::Package { .. } => InformationRequestTag::Package,
+            InformationRequest::Entity { .. } => InformationRequestTag::Entity,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match InformationRequestTag::random(rng) {
+            InformationRequestTag::BlockHeader => InformationRequest::BlockHeader(
+                rng.gen::<bool>().then(|| BlockIdentifier::random(rng)),
+            ),
+            InformationRequestTag::SignedBlock => InformationRequest::SignedBlock(
+                rng.gen::<bool>().then(|| BlockIdentifier::random(rng)),
+            ),
+            InformationRequestTag::Transaction => InformationRequest::Transaction {
+                hash: TransactionHash::random(rng),
+                with_finalized_approvals: rng.gen(),
+            },
+            InformationRequestTag::Peers => InformationRequest::Peers,
+            InformationRequestTag::Uptime => InformationRequest::Uptime,
+            InformationRequestTag::LastProgress => InformationRequest::LastProgress,
+            InformationRequestTag::ReactorState => InformationRequest::ReactorState,
+            InformationRequestTag::NetworkName => InformationRequest::NetworkName,
+            InformationRequestTag::ConsensusValidatorChanges => {
+                InformationRequest::ConsensusValidatorChanges
+            }
+            InformationRequestTag::BlockSynchronizerStatus => {
+                InformationRequest::BlockSynchronizerStatus
+            }
+            InformationRequestTag::AvailableBlockRange => InformationRequest::AvailableBlockRange,
+            InformationRequestTag::NextUpgrade => InformationRequest::NextUpgrade,
+            InformationRequestTag::ConsensusStatus => InformationRequest::ConsensusStatus,
+            InformationRequestTag::ChainspecRawBytes => InformationRequest::ChainspecRawBytes,
+            InformationRequestTag::NodeStatus => InformationRequest::NodeStatus,
+            InformationRequestTag::LatestSwitchBlockHeader => {
+                InformationRequest::LatestSwitchBlockHeader
+            }
+            InformationRequestTag::Reward => InformationRequest::Reward {
+                era_identifier: rng.gen::<bool>().then(|| EraIdentifier::random(rng)),
+                validator: PublicKey::random(rng).into(),
+                delegator: rng.gen::<bool>().then(|| PublicKey::random(rng).into()),
+            },
+            InformationRequestTag::ProtocolVersion => InformationRequest::ProtocolVersion,
+            InformationRequestTag::Package => InformationRequest::Package {
+                state_identifier: rng
+                    .gen::<bool>()
+                    .then(|| GlobalStateIdentifier::random(rng)),
+                identifier: PackageIdentifier::random(rng),
+            },
+            InformationRequestTag::Entity => InformationRequest::Entity {
+                state_identifier: rng
+                    .gen::<bool>()
+                    .then(|| GlobalStateIdentifier::random(rng)),
+                identifier: EntityIdentifier::random(rng),
+                include_bytecode: rng.gen(),
+            },
+        }
+    }
+}
+
+impl ToBytes for InformationRequest {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            InformationRequest::BlockHeader(block_identifier) => {
+                block_identifier.write_bytes(writer)
+            }
+            InformationRequest::SignedBlock(block_identifier) => {
+                block_identifier.write_bytes(writer)
+            }
+            InformationRequest::Transaction {
+                hash,
+                with_finalized_approvals,
+            } => {
+                hash.write_bytes(writer)?;
+                with_finalized_approvals.write_bytes(writer)
+            }
+            InformationRequest::Peers
+            | InformationRequest::Uptime
+            | InformationRequest::LastProgress
+            | InformationRequest::ReactorState
+            | InformationRequest::NetworkName
+            | InformationRequest::ConsensusValidatorChanges
+            | InformationRequest::BlockSynchronizerStatus
+            | InformationRequest::AvailableBlockRange
+            | InformationRequest::NextUpgrade
+            | InformationRequest::ConsensusStatus
+            | InformationRequest::ChainspecRawBytes
+            | InformationRequest::NodeStatus
+            | InformationRequest::LatestSwitchBlockHeader
+            | InformationRequest::ProtocolVersion => Ok(()),
+            InformationRequest::Reward {
+                era_identifier,
+                validator,
+                delegator,
+            } => {
+                era_identifier.write_bytes(writer)?;
+                validator.write_bytes(writer)?;
+                delegator.as_deref().write_bytes(writer)?;
+                Ok(())
+            }
+            InformationRequest::Package {
+                state_identifier,
+                identifier,
+            } => {
+                state_identifier.write_bytes(writer)?;
+                identifier.write_bytes(writer)
+            }
+            InformationRequest::Entity {
+                state_identifier,
+                identifier,
+                include_bytecode,
+            } => {
+                state_identifier.write_bytes(writer)?;
+                identifier.write_bytes(writer)?;
+                include_bytecode.write_bytes(writer)
+            }
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        match self {
+            InformationRequest::BlockHeader(block_identifier) => {
+                block_identifier.serialized_length()
+            }
+            InformationRequest::SignedBlock(block_identifier) => {
+                block_identifier.serialized_length()
+            }
+            InformationRequest::Transaction {
+                hash,
+                with_finalized_approvals,
+            } => hash.serialized_length() + with_finalized_approvals.serialized_length(),
+            InformationRequest::Peers
+            | InformationRequest::Uptime
+            | InformationRequest::LastProgress
+            | InformationRequest::ReactorState
+            | InformationRequest::NetworkName
+            | InformationRequest::ConsensusValidatorChanges
+            | InformationRequest::BlockSynchronizerStatus
+            | InformationRequest::AvailableBlockRange
+            | InformationRequest::NextUpgrade
+            | InformationRequest::ConsensusStatus
+            | InformationRequest::ChainspecRawBytes
+            | InformationRequest::NodeStatus
+            | InformationRequest::LatestSwitchBlockHeader
+            | InformationRequest::ProtocolVersion => 0,
+            InformationRequest::Reward {
+                era_identifier,
+                validator,
+                delegator,
+            } => {
+                era_identifier.serialized_length()
+                    + validator.serialized_length()
+                    + delegator.as_deref().serialized_length()
+            }
+            InformationRequest::Package {
+                state_identifier,
+                identifier,
+            } => state_identifier.serialized_length() + identifier.serialized_length(),
+            InformationRequest::Entity {
+                state_identifier,
+                identifier,
+                include_bytecode,
+            } => {
+                state_identifier.serialized_length()
+                    + identifier.serialized_length()
+                    + include_bytecode.serialized_length()
+            }
+        }
+    }
+}
+
+impl TryFrom<(InformationRequestTag, &[u8])> for InformationRequest {
+    type Error = bytesrepr::Error;
+
+    fn try_from((tag, key_bytes): (InformationRequestTag, &[u8])) -> Result<Self, Self::Error> {
+        let (req, remainder) = match tag {
+            InformationRequestTag::BlockHeader => {
+                let (block_identifier, remainder) = FromBytes::from_bytes(key_bytes)?;
+                (InformationRequest::BlockHeader(block_identifier), remainder)
+            }
+            InformationRequestTag::SignedBlock => {
+                let (block_identifier, remainder) = FromBytes::from_bytes(key_bytes)?;
+                (InformationRequest::SignedBlock(block_identifier), remainder)
+            }
+            InformationRequestTag::Transaction => {
+                let (hash, remainder) = FromBytes::from_bytes(key_bytes)?;
+                let (with_finalized_approvals, remainder) = FromBytes::from_bytes(remainder)?;
+                (
+                    InformationRequest::Transaction {
+                        hash,
+                        with_finalized_approvals,
+                    },
+                    remainder,
+                )
+            }
+            InformationRequestTag::Peers => (InformationRequest::Peers, key_bytes),
+            InformationRequestTag::Uptime => (InformationRequest::Uptime, key_bytes),
+            InformationRequestTag::LastProgress => (InformationRequest::LastProgress, key_bytes),
+            InformationRequestTag::ReactorState => (InformationRequest::ReactorState, key_bytes),
+            InformationRequestTag::NetworkName => (InformationRequest::NetworkName, key_bytes),
+            InformationRequestTag::ConsensusValidatorChanges => {
+                (InformationRequest::ConsensusValidatorChanges, key_bytes)
+            }
+            InformationRequestTag::BlockSynchronizerStatus => {
+                (InformationRequest::BlockSynchronizerStatus, key_bytes)
+            }
+            InformationRequestTag::AvailableBlockRange => {
+                (InformationRequest::AvailableBlockRange, key_bytes)
+            }
+            InformationRequestTag::NextUpgrade => (InformationRequest::NextUpgrade, key_bytes),
+            InformationRequestTag::ConsensusStatus => {
+                (InformationRequest::ConsensusStatus, key_bytes)
+            }
+            InformationRequestTag::ChainspecRawBytes => {
+                (InformationRequest::ChainspecRawBytes, key_bytes)
+            }
+            InformationRequestTag::NodeStatus => (InformationRequest::NodeStatus, key_bytes),
+            InformationRequestTag::LatestSwitchBlockHeader => {
+                (InformationRequest::LatestSwitchBlockHeader, key_bytes)
+            }
+            InformationRequestTag::Reward => {
+                let (era_identifier, remainder) = <Option<EraIdentifier>>::from_bytes(key_bytes)?;
+                let (validator, remainder) = PublicKey::from_bytes(remainder)?;
+                let (delegator, remainder) = <Option<PublicKey>>::from_bytes(remainder)?;
+                (
+                    InformationRequest::Reward {
+                        era_identifier,
+                        validator: Box::new(validator),
+                        delegator: delegator.map(Box::new),
+                    },
+                    remainder,
+                )
+            }
+            InformationRequestTag::ProtocolVersion => {
+                (InformationRequest::ProtocolVersion, key_bytes)
+            }
+            InformationRequestTag::Package => {
+                let (state_identifier, remainder) = FromBytes::from_bytes(key_bytes)?;
+                let (identifier, remainder) = FromBytes::from_bytes(remainder)?;
+                (
+                    InformationRequest::Package {
+                        state_identifier,
+                        identifier,
+                    },
+                    remainder,
+                )
+            }
+            InformationRequestTag::Entity => {
+                let (state_identifier, remainder) = FromBytes::from_bytes(key_bytes)?;
+                let (identifier, remainder) = FromBytes::from_bytes(remainder)?;
+                let (include_bytecode, remainder) = FromBytes::from_bytes(remainder)?;
+                (
+                    InformationRequest::Entity {
+                        state_identifier,
+                        identifier,
+                        include_bytecode,
+                    },
+                    remainder,
+                )
+            }
+        };
+        if !remainder.is_empty() {
+            return Err(bytesrepr::Error::LeftOverBytes);
+        }
+        Ok(req)
+    }
+}
+
+impl TryFrom<InformationRequest> for GetRequest {
+    type Error = bytesrepr::Error;
+
+    fn try_from(request: InformationRequest) -> Result<Self, Self::Error> {
+        Ok(GetRequest::Information {
+            info_type_tag: request.tag().into(),
+            key: request.to_bytes()?,
+        })
+    }
+}
+
+/// Identifier of an information request.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[repr(u16)]
+pub enum InformationRequestTag {
+    /// Block header request.
+    BlockHeader = 0,
+    /// Signed block request.
+    SignedBlock = 1,
+    /// Transaction request.
+    Transaction = 2,
+    /// Peers request.
+    Peers = 3,
+    /// Uptime request.
+    Uptime = 4,
+    /// Last progress request.
+    LastProgress = 5,
+    /// Reactor state request.
+    ReactorState = 6,
+    /// Network name request.
+    NetworkName = 7,
+    /// Consensus validator changes request.
+    ConsensusValidatorChanges = 8,
+    /// Block synchronizer status request.
+    BlockSynchronizerStatus = 9,
+    /// Available block range request.
+    AvailableBlockRange = 10,
+    /// Next upgrade request.
+    NextUpgrade = 11,
+    /// Consensus status request.
+    ConsensusStatus = 12,
+    /// Chainspec raw bytes request.
+    ChainspecRawBytes = 13,
+    /// Node status request.
+    NodeStatus = 14,
+    /// Latest switch block header request.
+    LatestSwitchBlockHeader = 15,
+    /// Reward for a validator or a delegator in a specific era.
+    Reward = 16,
+    /// Protocol version request.
+    ProtocolVersion = 17,
+    /// Contract package request.
+    Package = 18,
+    /// Addressable entity request.
+    Entity = 19,
+}
+
+impl InformationRequestTag {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..20) {
+            0 => InformationRequestTag::BlockHeader,
+            1 => InformationRequestTag::SignedBlock,
+            2 => InformationRequestTag::Transaction,
+            3 => InformationRequestTag::Peers,
+            4 => InformationRequestTag::Uptime,
+            5 => InformationRequestTag::LastProgress,
+            6 => InformationRequestTag::ReactorState,
+            7 => InformationRequestTag::NetworkName,
+            8 => InformationRequestTag::ConsensusValidatorChanges,
+            9 => InformationRequestTag::BlockSynchronizerStatus,
+            10 => InformationRequestTag::AvailableBlockRange,
+            11 => InformationRequestTag::NextUpgrade,
+            12 => InformationRequestTag::ConsensusStatus,
+            13 => InformationRequestTag::ChainspecRawBytes,
+            14 => InformationRequestTag::NodeStatus,
+            15 => InformationRequestTag::LatestSwitchBlockHeader,
+            16 => InformationRequestTag::Reward,
+            17 => InformationRequestTag::ProtocolVersion,
+            18 => InformationRequestTag::Package,
+            19 => InformationRequestTag::Entity,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl TryFrom<u16> for InformationRequestTag {
+    type Error = UnknownInformationRequestTag;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(InformationRequestTag::BlockHeader),
+            1 => Ok(InformationRequestTag::SignedBlock),
+            2 => Ok(InformationRequestTag::Transaction),
+            3 => Ok(InformationRequestTag::Peers),
+            4 => Ok(InformationRequestTag::Uptime),
+            5 => Ok(InformationRequestTag::LastProgress),
+            6 => Ok(InformationRequestTag::ReactorState),
+            7 => Ok(InformationRequestTag::NetworkName),
+            8 => Ok(InformationRequestTag::ConsensusValidatorChanges),
+            9 => Ok(InformationRequestTag::BlockSynchronizerStatus),
+            10 => Ok(InformationRequestTag::AvailableBlockRange),
+            11 => Ok(InformationRequestTag::NextUpgrade),
+            12 => Ok(InformationRequestTag::ConsensusStatus),
+            13 => Ok(InformationRequestTag::ChainspecRawBytes),
+            14 => Ok(InformationRequestTag::NodeStatus),
+            15 => Ok(InformationRequestTag::LatestSwitchBlockHeader),
+            16 => Ok(InformationRequestTag::Reward),
+            17 => Ok(InformationRequestTag::ProtocolVersion),
+            18 => Ok(InformationRequestTag::Package),
+            19 => Ok(InformationRequestTag::Entity),
+            _ => Err(UnknownInformationRequestTag(value)),
+        }
+    }
+}
+
+impl From<InformationRequestTag> for u16 {
+    fn from(value: InformationRequestTag) -> Self {
+        value as u16
+    }
+}
+
+/// Error returned when trying to convert a `u16` into a `RecordId`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnknownInformationRequestTag(u16);
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EntityIdentifier {
+    ContractHash(ContractHash),
+    AccountHash(AccountHash),
+    PublicKey(PublicKey),
+    EntityAddr(EntityAddr),
+}
+
+impl EntityIdentifier {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..4) {
+            0 => EntityIdentifier::ContractHash(ContractHash::new(rng.gen())),
+            1 => EntityIdentifier::PublicKey(PublicKey::random(rng)),
+            2 => EntityIdentifier::AccountHash(AccountHash::new(rng.gen())),
+            3 => EntityIdentifier::EntityAddr(rng.gen()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl FromBytes for EntityIdentifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        let (identifier, remainder) = match tag {
+            0 => {
+                let (hash, remainder) = FromBytes::from_bytes(remainder)?;
+                (EntityIdentifier::ContractHash(hash), remainder)
+            }
+            1 => {
+                let (key, remainder) = FromBytes::from_bytes(remainder)?;
+                (EntityIdentifier::PublicKey(key), remainder)
+            }
+            2 => {
+                let (hash, remainder) = FromBytes::from_bytes(remainder)?;
+                (EntityIdentifier::AccountHash(hash), remainder)
+            }
+            3 => {
+                let (entity, remainder) = FromBytes::from_bytes(remainder)?;
+                (EntityIdentifier::EntityAddr(entity), remainder)
+            }
+            _ => return Err(bytesrepr::Error::Formatting),
+        };
+        Ok((identifier, remainder))
+    }
+}
+
+impl ToBytes for EntityIdentifier {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let tag: u8 = match self {
+            EntityIdentifier::ContractHash(_) => 0,
+            EntityIdentifier::PublicKey(_) => 1,
+            EntityIdentifier::AccountHash(_) => 2,
+            EntityIdentifier::EntityAddr(_) => 3,
+        };
+        tag.write_bytes(writer)?;
+        match self {
+            EntityIdentifier::ContractHash(hash) => hash.write_bytes(writer),
+            EntityIdentifier::PublicKey(key) => key.write_bytes(writer),
+            EntityIdentifier::AccountHash(hash) => hash.write_bytes(writer),
+            EntityIdentifier::EntityAddr(entity) => entity.write_bytes(writer),
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        let identifier_length = match self {
+            EntityIdentifier::ContractHash(hash) => hash.serialized_length(),
+            EntityIdentifier::PublicKey(key) => key.serialized_length(),
+            EntityIdentifier::AccountHash(hash) => hash.serialized_length(),
+            EntityIdentifier::EntityAddr(entity) => entity.serialized_length(),
+        };
+        U8_SERIALIZED_LENGTH + identifier_length
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PackageIdentifier {
+    ContractPackageHash(ContractPackageHash),
+    PackageAddr(PackageAddr),
+}
+
+impl PackageIdentifier {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..2) {
+            0 => PackageIdentifier::ContractPackageHash(ContractPackageHash::new(rng.gen())),
+            1 => PackageIdentifier::PackageAddr(rng.gen()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl FromBytes for PackageIdentifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        let (identifier, remainder) = match tag {
+            0 => {
+                let (hash, remainder) = FromBytes::from_bytes(remainder)?;
+                (PackageIdentifier::ContractPackageHash(hash), remainder)
+            }
+            1 => {
+                let (addr, remainder) = FromBytes::from_bytes(remainder)?;
+                (PackageIdentifier::PackageAddr(addr), remainder)
+            }
+            _ => return Err(bytesrepr::Error::Formatting),
+        };
+        Ok((identifier, remainder))
+    }
+}
+
+impl ToBytes for PackageIdentifier {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let tag: u8 = match self {
+            PackageIdentifier::ContractPackageHash(_) => 0,
+            PackageIdentifier::PackageAddr(_) => 1,
+        };
+        tag.write_bytes(writer)?;
+        match self {
+            PackageIdentifier::ContractPackageHash(hash) => hash.write_bytes(writer),
+            PackageIdentifier::PackageAddr(addr) => addr.write_bytes(writer),
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        let identifier_length = match self {
+            PackageIdentifier::ContractPackageHash(hash) => hash.serialized_length(),
+            PackageIdentifier::PackageAddr(addr) => addr.serialized_length(),
+        };
+        U8_SERIALIZED_LENGTH + identifier_length
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn tag_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = InformationRequestTag::random(rng);
+        let tag = u16::from(val);
+        assert_eq!(InformationRequestTag::try_from(tag), Ok(val));
+    }
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = InformationRequest::random(rng);
+        let bytes = val.to_bytes().expect("should serialize");
+        assert_eq!(
+            InformationRequest::try_from((val.tag(), &bytes[..])),
+            Ok(val)
+        );
+    }
+
+    #[test]
+    fn entity_identifier_bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = EntityIdentifier::random(rng);
+        let bytes = val.to_bytes().expect("should serialize");
+        assert_eq!(bytesrepr::deserialize_from_slice(bytes), Ok(val));
+    }
+
+    #[test]
+    fn package_identifier_bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = PackageIdentifier::random(rng);
+        let bytes = val.to_bytes().expect("should serialize");
+        assert_eq!(bytesrepr::deserialize_from_slice(bytes), Ok(val));
+    }
+}

--- a/binary_port/src/key_prefix.rs
+++ b/binary_port/src/key_prefix.rs
@@ -1,0 +1,202 @@
+#[cfg(any(feature = "testing", test))]
+use casper_types::testing::TestRng;
+use casper_types::{
+    account::AccountHash,
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    contract_messages::TopicNameHash,
+    system::{auction::BidAddrTag, mint::BalanceHoldAddrTag},
+    EntityAddr, HashAddr, KeyTag, URefAddr,
+};
+#[cfg(any(feature = "testing", test))]
+use rand::Rng;
+
+/// Key prefixes used for querying the global state.
+#[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
+pub enum KeyPrefix {
+    /// Retrieves all delegator bid addresses for a given validator.
+    DelegatorBidAddrsByValidator(AccountHash),
+    /// Retrieves all messages for a given entity.
+    MessagesByEntity(HashAddr),
+    /// Retrieves all messages for a given entity and topic.
+    MessagesByEntityAndTopic(HashAddr, TopicNameHash),
+    /// Retrieves all named keys for a given entity.
+    NamedKeysByEntity(EntityAddr),
+    /// Retrieves all gas balance holds for a given purse.
+    GasBalanceHoldsByPurse(URefAddr),
+    /// Retrieves all processing balance holds for a given purse.
+    ProcessingBalanceHoldsByPurse(URefAddr),
+    /// Retrieves all V1 entry points for a given entity.
+    EntryPointsV1ByEntity(EntityAddr),
+    /// Retrieves all V2 entry points for a given entity.
+    EntryPointsV2ByEntity(EntityAddr),
+}
+
+impl KeyPrefix {
+    /// Returns a random `KeyPrefix`.
+    #[cfg(any(feature = "testing", test))]
+    pub fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..8) {
+            0 => KeyPrefix::DelegatorBidAddrsByValidator(rng.gen()),
+            1 => KeyPrefix::MessagesByEntity(rng.gen()),
+            2 => KeyPrefix::MessagesByEntityAndTopic(rng.gen(), rng.gen()),
+            3 => KeyPrefix::NamedKeysByEntity(rng.gen()),
+            4 => KeyPrefix::GasBalanceHoldsByPurse(rng.gen()),
+            5 => KeyPrefix::ProcessingBalanceHoldsByPurse(rng.gen()),
+            6 => KeyPrefix::EntryPointsV1ByEntity(rng.gen()),
+            7 => KeyPrefix::EntryPointsV2ByEntity(rng.gen()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl ToBytes for KeyPrefix {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut result = bytesrepr::unchecked_allocate_buffer(self);
+        self.write_bytes(&mut result)?;
+        Ok(result)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            KeyPrefix::DelegatorBidAddrsByValidator(validator) => {
+                writer.push(KeyTag::BidAddr as u8);
+                writer.push(BidAddrTag::Delegator as u8);
+                validator.write_bytes(writer)?;
+            }
+            KeyPrefix::MessagesByEntity(entity) => {
+                writer.push(KeyTag::Message as u8);
+                entity.write_bytes(writer)?;
+            }
+            KeyPrefix::MessagesByEntityAndTopic(entity, topic) => {
+                writer.push(KeyTag::Message as u8);
+                entity.write_bytes(writer)?;
+                topic.write_bytes(writer)?;
+            }
+            KeyPrefix::NamedKeysByEntity(entity) => {
+                writer.push(KeyTag::NamedKey as u8);
+                entity.write_bytes(writer)?;
+            }
+            KeyPrefix::GasBalanceHoldsByPurse(uref) => {
+                writer.push(KeyTag::BalanceHold as u8);
+                writer.push(BalanceHoldAddrTag::Gas as u8);
+                uref.write_bytes(writer)?;
+            }
+            KeyPrefix::ProcessingBalanceHoldsByPurse(uref) => {
+                writer.push(KeyTag::BalanceHold as u8);
+                writer.push(BalanceHoldAddrTag::Processing as u8);
+                uref.write_bytes(writer)?;
+            }
+            KeyPrefix::EntryPointsV1ByEntity(entity) => {
+                writer.push(KeyTag::EntryPoint as u8);
+                writer.push(0);
+                entity.write_bytes(writer)?;
+            }
+            KeyPrefix::EntryPointsV2ByEntity(entity) => {
+                writer.push(KeyTag::EntryPoint as u8);
+                writer.push(1);
+                entity.write_bytes(writer)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                KeyPrefix::DelegatorBidAddrsByValidator(validator) => {
+                    U8_SERIALIZED_LENGTH + validator.serialized_length()
+                }
+                KeyPrefix::MessagesByEntity(entity) => entity.serialized_length(),
+                KeyPrefix::MessagesByEntityAndTopic(entity, topic) => {
+                    entity.serialized_length() + topic.serialized_length()
+                }
+                KeyPrefix::NamedKeysByEntity(entity) => entity.serialized_length(),
+                KeyPrefix::GasBalanceHoldsByPurse(uref) => {
+                    U8_SERIALIZED_LENGTH + uref.serialized_length()
+                }
+                KeyPrefix::ProcessingBalanceHoldsByPurse(uref) => {
+                    U8_SERIALIZED_LENGTH + uref.serialized_length()
+                }
+                KeyPrefix::EntryPointsV1ByEntity(entity) => {
+                    U8_SERIALIZED_LENGTH + entity.serialized_length()
+                }
+                KeyPrefix::EntryPointsV2ByEntity(entity) => {
+                    U8_SERIALIZED_LENGTH + entity.serialized_length()
+                }
+            }
+    }
+}
+
+impl FromBytes for KeyPrefix {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        let result = match tag {
+            tag if tag == KeyTag::BidAddr as u8 => {
+                let (bid_addr_tag, remainder) = u8::from_bytes(remainder)?;
+                match bid_addr_tag {
+                    tag if tag == BidAddrTag::Delegator as u8 => {
+                        let (validator, remainder) = AccountHash::from_bytes(remainder)?;
+                        (
+                            KeyPrefix::DelegatorBidAddrsByValidator(validator),
+                            remainder,
+                        )
+                    }
+                    _ => return Err(bytesrepr::Error::Formatting),
+                }
+            }
+            tag if tag == KeyTag::Message as u8 => {
+                let (hash_addr, remainder) = HashAddr::from_bytes(remainder)?;
+                if remainder.is_empty() {
+                    (KeyPrefix::MessagesByEntity(hash_addr), remainder)
+                } else {
+                    let (topic, remainder) = TopicNameHash::from_bytes(remainder)?;
+                    (
+                        KeyPrefix::MessagesByEntityAndTopic(hash_addr, topic),
+                        remainder,
+                    )
+                }
+            }
+            tag if tag == KeyTag::NamedKey as u8 => {
+                let (entity, remainder) = EntityAddr::from_bytes(remainder)?;
+                (KeyPrefix::NamedKeysByEntity(entity), remainder)
+            }
+            tag if tag == KeyTag::BalanceHold as u8 => {
+                let (balance_hold_addr_tag, remainder) = u8::from_bytes(remainder)?;
+                let (uref, remainder) = URefAddr::from_bytes(remainder)?;
+                match balance_hold_addr_tag {
+                    tag if tag == BalanceHoldAddrTag::Gas as u8 => {
+                        (KeyPrefix::GasBalanceHoldsByPurse(uref), remainder)
+                    }
+                    tag if tag == BalanceHoldAddrTag::Processing as u8 => {
+                        (KeyPrefix::ProcessingBalanceHoldsByPurse(uref), remainder)
+                    }
+                    _ => return Err(bytesrepr::Error::Formatting),
+                }
+            }
+            tag if tag == KeyTag::EntryPoint as u8 => {
+                let (entry_point_type, remainder) = u8::from_bytes(remainder)?;
+                let (entity, remainder) = EntityAddr::from_bytes(remainder)?;
+                match entry_point_type {
+                    0 => (KeyPrefix::EntryPointsV1ByEntity(entity), remainder),
+                    1 => (KeyPrefix::EntryPointsV2ByEntity(entity), remainder),
+                    _ => return Err(bytesrepr::Error::Formatting),
+                }
+            }
+            _ => return Err(bytesrepr::Error::Formatting),
+        };
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let key_prefix = KeyPrefix::random(rng);
+        bytesrepr::test_serialization_roundtrip(&key_prefix);
+    }
+}

--- a/binary_port/src/lib.rs
+++ b/binary_port/src/lib.rs
@@ -1,0 +1,54 @@
+mod balance_response;
+mod binary_message;
+mod binary_request;
+mod binary_response;
+mod binary_response_and_request;
+mod binary_response_header;
+mod dictionary_item_identifier;
+mod entity_qualifier;
+mod era_identifier;
+mod error;
+mod error_code;
+mod get_request;
+mod global_state_query_result;
+mod information_request;
+mod key_prefix;
+mod minimal_block_info;
+mod node_status;
+mod original_request_context;
+mod purse_identifier;
+mod record_id;
+mod response_type;
+mod speculative_execution_result;
+mod state_request;
+mod type_wrappers;
+
+pub use balance_response::BalanceResponse;
+pub use binary_message::{BinaryMessage, BinaryMessageCodec};
+pub use binary_request::{BinaryRequest, BinaryRequestHeader};
+pub use binary_response::BinaryResponse;
+pub use binary_response_and_request::BinaryResponseAndRequest;
+pub use binary_response_header::BinaryResponseHeader;
+pub use dictionary_item_identifier::DictionaryItemIdentifier;
+pub use entity_qualifier::GlobalStateEntityQualifier;
+pub use era_identifier::EraIdentifier;
+pub use error::Error;
+pub use error_code::ErrorCode;
+pub use get_request::GetRequest;
+pub use global_state_query_result::GlobalStateQueryResult;
+pub use information_request::{
+    EntityIdentifier, InformationRequest, InformationRequestTag, PackageIdentifier,
+};
+pub use key_prefix::KeyPrefix;
+pub use minimal_block_info::MinimalBlockInfo;
+pub use node_status::NodeStatus;
+pub use purse_identifier::PurseIdentifier;
+pub use record_id::RecordId;
+pub use response_type::{PayloadEntity, ResponseType};
+pub use speculative_execution_result::SpeculativeExecutionResult;
+pub use state_request::GlobalStateRequest;
+pub use type_wrappers::{
+    AccountInformation, AddressableEntityInformation, ConsensusValidatorChanges,
+    ContractInformation, DictionaryQueryResult, GetTrieFullResult, RewardResponse,
+    TransactionWithExecutionInfo, Uptime, ValueWithProof,
+};

--- a/binary_port/src/minimal_block_info.rs
+++ b/binary_port/src/minimal_block_info.rs
@@ -1,0 +1,118 @@
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    Block, BlockHash, Digest, EraId, PublicKey, Timestamp,
+};
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use rand::Rng;
+use schemars::JsonSchema;
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+
+/// Minimal info about a `Block` needed to satisfy the node status request.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MinimalBlockInfo {
+    hash: BlockHash,
+    timestamp: Timestamp,
+    era_id: EraId,
+    height: u64,
+    state_root_hash: Digest,
+    creator: PublicKey,
+}
+
+impl MinimalBlockInfo {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        Self {
+            hash: BlockHash::random(rng),
+            timestamp: Timestamp::random(rng),
+            era_id: EraId::random(rng),
+            height: rng.gen(),
+            state_root_hash: Digest::random(rng),
+            creator: PublicKey::random(rng),
+        }
+    }
+}
+
+impl FromBytes for MinimalBlockInfo {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (hash, remainder) = BlockHash::from_bytes(bytes)?;
+        let (timestamp, remainder) = Timestamp::from_bytes(remainder)?;
+        let (era_id, remainder) = EraId::from_bytes(remainder)?;
+        let (height, remainder) = u64::from_bytes(remainder)?;
+        let (state_root_hash, remainder) = Digest::from_bytes(remainder)?;
+        let (creator, remainder) = PublicKey::from_bytes(remainder)?;
+        Ok((
+            MinimalBlockInfo {
+                hash,
+                timestamp,
+                era_id,
+                height,
+                state_root_hash,
+                creator,
+            },
+            remainder,
+        ))
+    }
+}
+
+impl ToBytes for MinimalBlockInfo {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.hash.write_bytes(writer)?;
+        self.timestamp.write_bytes(writer)?;
+        self.era_id.write_bytes(writer)?;
+        self.height.write_bytes(writer)?;
+        self.state_root_hash.write_bytes(writer)?;
+        self.creator.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.hash.serialized_length()
+            + self.timestamp.serialized_length()
+            + self.era_id.serialized_length()
+            + self.height.serialized_length()
+            + self.state_root_hash.serialized_length()
+            + self.creator.serialized_length()
+    }
+}
+
+impl From<Block> for MinimalBlockInfo {
+    fn from(block: Block) -> Self {
+        let proposer = match &block {
+            Block::V1(v1) => v1.proposer().clone(),
+            Block::V2(v2) => v2.proposer().clone(),
+        };
+
+        MinimalBlockInfo {
+            hash: *block.hash(),
+            timestamp: block.timestamp(),
+            era_id: block.era_id(),
+            height: block.height(),
+            state_root_hash: *block.state_root_hash(),
+            creator: proposer,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = MinimalBlockInfo::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/node_status.rs
+++ b/binary_port/src/node_status.rs
@@ -1,0 +1,188 @@
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    AvailableBlockRange, BlockHash, BlockSynchronizerStatus, Digest, NextUpgrade, Peers,
+    ProtocolVersion, PublicKey, TimeDiff, Timestamp,
+};
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+use serde::Serialize;
+
+use crate::{minimal_block_info::MinimalBlockInfo, type_wrappers::ReactorStateName};
+
+/// Status information about the node.
+#[derive(Debug, PartialEq, Serialize)]
+pub struct NodeStatus {
+    /// The current protocol version.
+    pub protocol_version: ProtocolVersion,
+    /// The node ID and network address of each connected peer.
+    pub peers: Peers,
+    /// The compiled node version.
+    pub build_version: String,
+    /// The chainspec name.
+    pub chainspec_name: String,
+    /// The state root hash of the lowest block in the available block range.
+    pub starting_state_root_hash: Digest,
+    /// The minimal info of the last block from the linear chain.
+    pub last_added_block_info: Option<MinimalBlockInfo>,
+    /// Our public signing key.
+    pub our_public_signing_key: Option<PublicKey>,
+    /// The next round length if this node is a validator.
+    pub round_length: Option<TimeDiff>,
+    /// Information about the next scheduled upgrade.
+    pub next_upgrade: Option<NextUpgrade>,
+    /// Time that passed since the node has started.
+    pub uptime: TimeDiff,
+    /// The current state of node reactor.
+    pub reactor_state: ReactorStateName,
+    /// Timestamp of the last recorded progress in the reactor.
+    pub last_progress: Timestamp,
+    /// The available block range in storage.
+    pub available_block_range: AvailableBlockRange,
+    /// The status of the block synchronizer builders.
+    pub block_sync: BlockSynchronizerStatus,
+    /// The hash of the latest switch block.
+    pub latest_switch_block_hash: Option<BlockHash>,
+}
+
+impl NodeStatus {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        Self {
+            protocol_version: ProtocolVersion::from_parts(rng.gen(), rng.gen(), rng.gen()),
+            peers: Peers::random(rng),
+            build_version: rng.random_string(5..10),
+            chainspec_name: rng.random_string(5..10),
+            starting_state_root_hash: Digest::random(rng),
+            last_added_block_info: rng.gen::<bool>().then_some(MinimalBlockInfo::random(rng)),
+            our_public_signing_key: rng.gen::<bool>().then_some(PublicKey::random(rng)),
+            round_length: rng
+                .gen::<bool>()
+                .then_some(TimeDiff::from_millis(rng.gen())),
+            next_upgrade: rng.gen::<bool>().then_some(NextUpgrade::random(rng)),
+            uptime: TimeDiff::from_millis(rng.gen()),
+            reactor_state: ReactorStateName::new(rng.random_string(5..10)),
+            last_progress: Timestamp::random(rng),
+            available_block_range: AvailableBlockRange::random(rng),
+            block_sync: BlockSynchronizerStatus::random(rng),
+            latest_switch_block_hash: rng.gen::<bool>().then_some(BlockHash::random(rng)),
+        }
+    }
+}
+
+impl FromBytes for NodeStatus {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (protocol_version, remainder) = ProtocolVersion::from_bytes(bytes)?;
+        let (peers, remainder) = Peers::from_bytes(remainder)?;
+        let (build_version, remainder) = String::from_bytes(remainder)?;
+        let (chainspec_name, remainder) = String::from_bytes(remainder)?;
+        let (starting_state_root_hash, remainder) = Digest::from_bytes(remainder)?;
+        let (last_added_block_info, remainder) = Option::<MinimalBlockInfo>::from_bytes(remainder)?;
+        let (our_public_signing_key, remainder) = Option::<PublicKey>::from_bytes(remainder)?;
+        let (round_length, remainder) = Option::<TimeDiff>::from_bytes(remainder)?;
+        let (next_upgrade, remainder) = Option::<NextUpgrade>::from_bytes(remainder)?;
+        let (uptime, remainder) = TimeDiff::from_bytes(remainder)?;
+        let (reactor_state, remainder) = ReactorStateName::from_bytes(remainder)?;
+        let (last_progress, remainder) = Timestamp::from_bytes(remainder)?;
+        let (available_block_range, remainder) = AvailableBlockRange::from_bytes(remainder)?;
+        let (block_sync, remainder) = BlockSynchronizerStatus::from_bytes(remainder)?;
+        let (latest_switch_block_hash, remainder) = Option::<BlockHash>::from_bytes(remainder)?;
+        Ok((
+            NodeStatus {
+                protocol_version,
+                peers,
+                build_version,
+                chainspec_name,
+                starting_state_root_hash,
+                last_added_block_info,
+                our_public_signing_key,
+                round_length,
+                next_upgrade,
+                uptime,
+                reactor_state,
+                last_progress,
+                available_block_range,
+                block_sync,
+                latest_switch_block_hash,
+            },
+            remainder,
+        ))
+    }
+}
+
+impl ToBytes for NodeStatus {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let NodeStatus {
+            protocol_version,
+            peers,
+            build_version,
+            chainspec_name,
+            starting_state_root_hash,
+            last_added_block_info,
+            our_public_signing_key,
+            round_length,
+            next_upgrade,
+            uptime,
+            reactor_state,
+            last_progress,
+            available_block_range,
+            block_sync,
+            latest_switch_block_hash,
+        } = self;
+        protocol_version.write_bytes(writer)?;
+        peers.write_bytes(writer)?;
+        build_version.write_bytes(writer)?;
+        chainspec_name.write_bytes(writer)?;
+        starting_state_root_hash.write_bytes(writer)?;
+        last_added_block_info.write_bytes(writer)?;
+        our_public_signing_key.write_bytes(writer)?;
+        round_length.write_bytes(writer)?;
+        next_upgrade.write_bytes(writer)?;
+        uptime.write_bytes(writer)?;
+        reactor_state.write_bytes(writer)?;
+        last_progress.write_bytes(writer)?;
+        available_block_range.write_bytes(writer)?;
+        block_sync.write_bytes(writer)?;
+        latest_switch_block_hash.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.protocol_version.serialized_length()
+            + self.peers.serialized_length()
+            + self.build_version.serialized_length()
+            + self.chainspec_name.serialized_length()
+            + self.starting_state_root_hash.serialized_length()
+            + self.last_added_block_info.serialized_length()
+            + self.our_public_signing_key.serialized_length()
+            + self.round_length.serialized_length()
+            + self.next_upgrade.serialized_length()
+            + self.uptime.serialized_length()
+            + self.reactor_state.serialized_length()
+            + self.last_progress.serialized_length()
+            + self.available_block_range.serialized_length()
+            + self.block_sync.serialized_length()
+            + self.latest_switch_block_hash.serialized_length()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = NodeStatus::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/original_request_context.rs
+++ b/binary_port/src/original_request_context.rs
@@ -1,0 +1,83 @@
+use casper_types::bytesrepr::{self, Bytes, FromBytes, ToBytes};
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct OriginalRequestContext {
+    // The ID of the original request.
+    id: u16,
+    // The original request (as serialized bytes).
+    data: Vec<u8>,
+}
+
+impl OriginalRequestContext {
+    pub(crate) fn new(id: u16, data: Vec<u8>) -> Self {
+        Self { id, data }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        Self {
+            id: rng.gen(),
+            data: rng.random_vec(64..128),
+        }
+    }
+
+    pub(crate) fn id(&self) -> u16 {
+        self.id
+    }
+
+    pub(crate) fn data(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl ToBytes for OriginalRequestContext {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        let OriginalRequestContext { id, data } = self;
+
+        id.write_bytes(writer)?;
+        data.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.id.serialized_length() + self.data.serialized_length()
+    }
+}
+
+impl FromBytes for OriginalRequestContext {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (id, remainder) = FromBytes::from_bytes(bytes)?;
+        let (data, remainder) = Bytes::from_bytes(remainder)?;
+
+        Ok((
+            OriginalRequestContext {
+                id,
+                data: data.into(),
+            },
+            remainder,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = OriginalRequestContext::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/purse_identifier.rs
+++ b/binary_port/src/purse_identifier.rs
@@ -1,0 +1,127 @@
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+use casper_types::{
+    account::AccountHash,
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    EntityAddr, PublicKey, URef,
+};
+
+const PAYMENT_PURSE_TAG: u8 = 0;
+const ACCUMULATE_PURSE_TAG: u8 = 1;
+const UREF_PURSE_TAG: u8 = 2;
+const PUBLIC_KEY_PURSE_TAG: u8 = 3;
+const ACCOUNT_PURSE_TAG: u8 = 4;
+const ENTITY_PURSE_TAG: u8 = 5;
+
+/// Identifier for balance lookup.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PurseIdentifier {
+    Payment,
+    Accumulate,
+    Purse(URef),
+    PublicKey(PublicKey),
+    Account(AccountHash),
+    Entity(EntityAddr),
+}
+
+impl PurseIdentifier {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..6) {
+            PAYMENT_PURSE_TAG => PurseIdentifier::Payment,
+            ACCUMULATE_PURSE_TAG => PurseIdentifier::Accumulate,
+            UREF_PURSE_TAG => PurseIdentifier::Purse(rng.gen()),
+            PUBLIC_KEY_PURSE_TAG => PurseIdentifier::PublicKey(PublicKey::random(rng)),
+            ACCOUNT_PURSE_TAG => PurseIdentifier::Account(rng.gen()),
+            ENTITY_PURSE_TAG => PurseIdentifier::Entity(rng.gen()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl ToBytes for PurseIdentifier {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            PurseIdentifier::Payment => PAYMENT_PURSE_TAG.write_bytes(writer),
+            PurseIdentifier::Accumulate => ACCUMULATE_PURSE_TAG.write_bytes(writer),
+            PurseIdentifier::Purse(uref) => {
+                UREF_PURSE_TAG.write_bytes(writer)?;
+                uref.write_bytes(writer)
+            }
+            PurseIdentifier::PublicKey(key) => {
+                PUBLIC_KEY_PURSE_TAG.write_bytes(writer)?;
+                key.write_bytes(writer)
+            }
+            PurseIdentifier::Account(account) => {
+                ACCOUNT_PURSE_TAG.write_bytes(writer)?;
+                account.write_bytes(writer)
+            }
+            PurseIdentifier::Entity(entity) => {
+                ENTITY_PURSE_TAG.write_bytes(writer)?;
+                entity.write_bytes(writer)
+            }
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                PurseIdentifier::Payment => 0,
+                PurseIdentifier::Accumulate => 0,
+                PurseIdentifier::Purse(uref) => uref.serialized_length(),
+                PurseIdentifier::PublicKey(key) => key.serialized_length(),
+                PurseIdentifier::Account(account) => account.serialized_length(),
+                PurseIdentifier::Entity(entity) => entity.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for PurseIdentifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            PAYMENT_PURSE_TAG => Ok((PurseIdentifier::Payment, remainder)),
+            ACCUMULATE_PURSE_TAG => Ok((PurseIdentifier::Accumulate, remainder)),
+            UREF_PURSE_TAG => {
+                let (uref, remainder) = URef::from_bytes(remainder)?;
+                Ok((PurseIdentifier::Purse(uref), remainder))
+            }
+            PUBLIC_KEY_PURSE_TAG => {
+                let (key, remainder) = PublicKey::from_bytes(remainder)?;
+                Ok((PurseIdentifier::PublicKey(key), remainder))
+            }
+            ACCOUNT_PURSE_TAG => {
+                let (account, remainder) = AccountHash::from_bytes(remainder)?;
+                Ok((PurseIdentifier::Account(account), remainder))
+            }
+            ENTITY_PURSE_TAG => {
+                let (entity, remainder) = EntityAddr::from_bytes(remainder)?;
+                Ok((PurseIdentifier::Entity(entity), remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = PurseIdentifier::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/record_id.rs
+++ b/binary_port/src/record_id.rs
@@ -1,0 +1,114 @@
+use core::convert::TryFrom;
+
+#[cfg(test)]
+use rand::Rng;
+use serde::Serialize;
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(any(feature = "testing", test))]
+use strum::IntoEnumIterator;
+#[cfg(any(feature = "testing", test))]
+use strum_macros::EnumIter;
+
+/// An identifier of a record type.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize)]
+#[repr(u16)]
+#[cfg_attr(any(feature = "testing", test), derive(EnumIter))]
+pub enum RecordId {
+    /// Refers to `BlockHeader` record.
+    BlockHeader = 0,
+    /// Refers to `BlockBody` record.
+    BlockBody = 1,
+    /// Refers to `ApprovalsHashes` record.
+    ApprovalsHashes = 2,
+    /// Refers to `BlockMetadata` record.
+    BlockMetadata = 3,
+    /// Refers to `Transaction` record.
+    Transaction = 4,
+    /// Refers to `ExecutionResult` record.
+    ExecutionResult = 5,
+    /// Refers to `Transfer` record.
+    Transfer = 6,
+    /// Refers to `FinalizedTransactionApprovals` record.
+    FinalizedTransactionApprovals = 7,
+}
+
+impl RecordId {
+    #[cfg(test)]
+    pub fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..8) {
+            0 => RecordId::BlockHeader,
+            1 => RecordId::BlockBody,
+            2 => RecordId::ApprovalsHashes,
+            3 => RecordId::BlockMetadata,
+            4 => RecordId::Transaction,
+            5 => RecordId::ExecutionResult,
+            6 => RecordId::Transfer,
+            7 => RecordId::FinalizedTransactionApprovals,
+            _ => unreachable!(),
+        }
+    }
+    #[cfg(any(feature = "testing", test))]
+    pub fn all() -> impl Iterator<Item = RecordId> {
+        RecordId::iter()
+    }
+}
+
+impl TryFrom<u16> for RecordId {
+    type Error = UnknownRecordId;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(RecordId::BlockHeader),
+            1 => Ok(RecordId::BlockBody),
+            2 => Ok(RecordId::ApprovalsHashes),
+            3 => Ok(RecordId::BlockMetadata),
+            4 => Ok(RecordId::Transaction),
+            5 => Ok(RecordId::ExecutionResult),
+            6 => Ok(RecordId::Transfer),
+            7 => Ok(RecordId::FinalizedTransactionApprovals),
+            _ => Err(UnknownRecordId(value)),
+        }
+    }
+}
+
+impl From<RecordId> for u16 {
+    fn from(value: RecordId) -> Self {
+        value as u16
+    }
+}
+
+impl core::fmt::Display for RecordId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RecordId::BlockHeader => write!(f, "BlockHeader"),
+            RecordId::BlockBody => write!(f, "BlockBody"),
+            RecordId::ApprovalsHashes => write!(f, "ApprovalsHashes"),
+            RecordId::BlockMetadata => write!(f, "BlockMetadata"),
+            RecordId::Transaction => write!(f, "Transaction"),
+            RecordId::ExecutionResult => write!(f, "ExecutionResult"),
+            RecordId::Transfer => write!(f, "Transfer"),
+            RecordId::FinalizedTransactionApprovals => write!(f, "FinalizedTransactionApprovals"),
+        }
+    }
+}
+
+/// Error returned when trying to convert a `u16` into a `RecordId`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct UnknownRecordId(u16);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn tag_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = RecordId::random(rng);
+        let tag = u16::from(val);
+        assert_eq!(RecordId::try_from(tag), Ok(val));
+    }
+}

--- a/binary_port/src/response_type.rs
+++ b/binary_port/src/response_type.rs
@@ -1,0 +1,465 @@
+//! The payload type.
+
+use core::{convert::TryFrom, fmt};
+
+#[cfg(test)]
+use rand::Rng;
+
+#[cfg(test)]
+use casper_types::testing::TestRng;
+use casper_types::{
+    contracts::ContractPackage,
+    execution::{ExecutionResult, ExecutionResultV1},
+    AvailableBlockRange, BlockBody, BlockBodyV1, BlockHeader, BlockHeaderV1, BlockSignatures,
+    BlockSignaturesV1, BlockSynchronizerStatus, ChainspecRawBytes, Deploy, NextUpgrade, Package,
+    Peers, ProtocolVersion, SignedBlock, StoredValue, Transaction, Transfer,
+};
+
+use crate::{
+    global_state_query_result::GlobalStateQueryResult,
+    node_status::NodeStatus,
+    speculative_execution_result::SpeculativeExecutionResult,
+    type_wrappers::{
+        ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult, LastProgress, NetworkName,
+        ReactorStateName, RewardResponse,
+    },
+    AccountInformation, AddressableEntityInformation, BalanceResponse, ContractInformation,
+    DictionaryQueryResult, RecordId, TransactionWithExecutionInfo, Uptime, ValueWithProof,
+};
+
+/// A type of the payload being returned in a binary response.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ResponseType {
+    /// Legacy version of the block header.
+    BlockHeaderV1,
+    /// Block header.
+    BlockHeader,
+    /// Legacy version of the block body.
+    BlockBodyV1,
+    /// Block body.
+    BlockBody,
+    /// Legacy version of the approvals hashes.
+    ApprovalsHashesV1,
+    /// Approvals hashes
+    ApprovalsHashes,
+    /// Legacy version of the block signatures.
+    BlockSignaturesV1,
+    /// Block signatures.
+    BlockSignatures,
+    /// Deploy.
+    Deploy,
+    /// Transaction.
+    Transaction,
+    /// Legacy version of the execution result.
+    ExecutionResultV1,
+    /// Execution result.
+    ExecutionResult,
+    /// Wasm V1 execution result.
+    WasmV1Result,
+    /// Transfers.
+    Transfers,
+    /// Finalized deploy approvals.
+    FinalizedDeployApprovals,
+    /// Finalized approvals.
+    FinalizedApprovals,
+    /// Block with signatures.
+    SignedBlock,
+    /// Transaction with approvals and execution info.
+    TransactionWithExecutionInfo,
+    /// Peers.
+    Peers,
+    /// Last progress.
+    LastProgress,
+    /// State of the reactor.
+    ReactorState,
+    /// Network name.
+    NetworkName,
+    /// Consensus validator changes.
+    ConsensusValidatorChanges, // return type in `effects.rs` will be turned into dedicated type.
+    /// Status of the block synchronizer.
+    BlockSynchronizerStatus,
+    /// Available block range.
+    AvailableBlockRange,
+    /// Information about the next network upgrade.
+    NextUpgrade,
+    /// Consensus status.
+    ConsensusStatus, // return type in `effects.rs` will be turned into dedicated type.
+    /// Chainspec represented as raw bytes.
+    ChainspecRawBytes,
+    /// Uptime.
+    Uptime,
+    /// Result of checking if given block is in the highest available block range.
+    HighestBlockSequenceCheckResult,
+    /// Result of the speculative execution,
+    SpeculativeExecutionResult,
+    /// Result of querying global state,
+    GlobalStateQueryResult,
+    /// Result of querying global state for all values under a specified key.
+    StoredValues,
+    /// Result of querying global state for a full trie.
+    GetTrieFullResult,
+    /// Node status.
+    NodeStatus,
+    /// Result of querying for a dictionary item.
+    DictionaryQueryResult,
+    /// Balance query response.
+    BalanceResponse,
+    /// Reward response.
+    Reward,
+    /// Protocol version.
+    ProtocolVersion,
+    /// Contract package with Merkle proof.
+    ContractPackageWithProof,
+    /// Contract information.
+    ContractInformation,
+    /// Account information.
+    AccountInformation,
+    /// Package with Merkle proof.
+    PackageWithProof,
+    /// Addressable entity information.
+    AddressableEntityInformation,
+}
+
+impl ResponseType {
+    pub fn from_record_id(record_id: RecordId, is_legacy: bool) -> Self {
+        match (is_legacy, record_id) {
+            (true, RecordId::BlockHeader) => Self::BlockHeaderV1,
+            (true, RecordId::BlockBody) => Self::BlockBodyV1,
+            (true, RecordId::ApprovalsHashes) => Self::ApprovalsHashesV1,
+            (true, RecordId::BlockMetadata) => Self::BlockSignaturesV1,
+            (true, RecordId::Transaction) => Self::Deploy,
+            (true, RecordId::ExecutionResult) => Self::ExecutionResultV1,
+            (true, RecordId::Transfer) => Self::Transfers,
+            (true, RecordId::FinalizedTransactionApprovals) => Self::FinalizedDeployApprovals,
+            (false, RecordId::BlockHeader) => Self::BlockHeader,
+            (false, RecordId::BlockBody) => Self::BlockBody,
+            (false, RecordId::ApprovalsHashes) => Self::ApprovalsHashes,
+            (false, RecordId::BlockMetadata) => Self::BlockSignatures,
+            (false, RecordId::Transaction) => Self::Transaction,
+            (false, RecordId::ExecutionResult) => Self::ExecutionResult,
+            (false, RecordId::Transfer) => Self::Transfers,
+            (false, RecordId::FinalizedTransactionApprovals) => Self::FinalizedApprovals,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        Self::try_from(rng.gen_range(0..44)).unwrap()
+    }
+}
+
+impl TryFrom<u8> for ResponseType {
+    type Error = ();
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            x if x == ResponseType::BlockHeaderV1 as u8 => Ok(ResponseType::BlockHeaderV1),
+            x if x == ResponseType::BlockHeader as u8 => Ok(ResponseType::BlockHeader),
+            x if x == ResponseType::BlockBodyV1 as u8 => Ok(ResponseType::BlockBodyV1),
+            x if x == ResponseType::BlockBody as u8 => Ok(ResponseType::BlockBody),
+            x if x == ResponseType::ApprovalsHashesV1 as u8 => Ok(ResponseType::ApprovalsHashesV1),
+            x if x == ResponseType::ApprovalsHashes as u8 => Ok(ResponseType::ApprovalsHashes),
+            x if x == ResponseType::BlockSignaturesV1 as u8 => Ok(ResponseType::BlockSignaturesV1),
+            x if x == ResponseType::BlockSignatures as u8 => Ok(ResponseType::BlockSignatures),
+            x if x == ResponseType::Deploy as u8 => Ok(ResponseType::Deploy),
+            x if x == ResponseType::Transaction as u8 => Ok(ResponseType::Transaction),
+            x if x == ResponseType::ExecutionResultV1 as u8 => Ok(ResponseType::ExecutionResultV1),
+            x if x == ResponseType::ExecutionResult as u8 => Ok(ResponseType::ExecutionResult),
+            x if x == ResponseType::Transfers as u8 => Ok(ResponseType::Transfers),
+            x if x == ResponseType::FinalizedDeployApprovals as u8 => {
+                Ok(ResponseType::FinalizedDeployApprovals)
+            }
+            x if x == ResponseType::FinalizedApprovals as u8 => {
+                Ok(ResponseType::FinalizedApprovals)
+            }
+            x if x == ResponseType::SignedBlock as u8 => Ok(ResponseType::SignedBlock),
+            x if x == ResponseType::TransactionWithExecutionInfo as u8 => {
+                Ok(ResponseType::TransactionWithExecutionInfo)
+            }
+            x if x == ResponseType::Peers as u8 => Ok(ResponseType::Peers),
+            x if x == ResponseType::Uptime as u8 => Ok(ResponseType::Uptime),
+            x if x == ResponseType::LastProgress as u8 => Ok(ResponseType::LastProgress),
+            x if x == ResponseType::ReactorState as u8 => Ok(ResponseType::ReactorState),
+            x if x == ResponseType::NetworkName as u8 => Ok(ResponseType::NetworkName),
+            x if x == ResponseType::ConsensusValidatorChanges as u8 => {
+                Ok(ResponseType::ConsensusValidatorChanges)
+            }
+            x if x == ResponseType::BlockSynchronizerStatus as u8 => {
+                Ok(ResponseType::BlockSynchronizerStatus)
+            }
+            x if x == ResponseType::AvailableBlockRange as u8 => {
+                Ok(ResponseType::AvailableBlockRange)
+            }
+            x if x == ResponseType::NextUpgrade as u8 => Ok(ResponseType::NextUpgrade),
+            x if x == ResponseType::ConsensusStatus as u8 => Ok(ResponseType::ConsensusStatus),
+            x if x == ResponseType::ChainspecRawBytes as u8 => Ok(ResponseType::ChainspecRawBytes),
+            x if x == ResponseType::HighestBlockSequenceCheckResult as u8 => {
+                Ok(ResponseType::HighestBlockSequenceCheckResult)
+            }
+            x if x == ResponseType::SpeculativeExecutionResult as u8 => {
+                Ok(ResponseType::SpeculativeExecutionResult)
+            }
+            x if x == ResponseType::GlobalStateQueryResult as u8 => {
+                Ok(ResponseType::GlobalStateQueryResult)
+            }
+            x if x == ResponseType::StoredValues as u8 => Ok(ResponseType::StoredValues),
+            x if x == ResponseType::GetTrieFullResult as u8 => Ok(ResponseType::GetTrieFullResult),
+            x if x == ResponseType::NodeStatus as u8 => Ok(ResponseType::NodeStatus),
+            x if x == ResponseType::DictionaryQueryResult as u8 => {
+                Ok(ResponseType::DictionaryQueryResult)
+            }
+            x if x == ResponseType::WasmV1Result as u8 => Ok(ResponseType::WasmV1Result),
+            x if x == ResponseType::BalanceResponse as u8 => Ok(ResponseType::BalanceResponse),
+            x if x == ResponseType::Reward as u8 => Ok(ResponseType::Reward),
+            x if x == ResponseType::ProtocolVersion as u8 => Ok(ResponseType::ProtocolVersion),
+            x if x == ResponseType::ContractPackageWithProof as u8 => {
+                Ok(ResponseType::ContractPackageWithProof)
+            }
+            x if x == ResponseType::ContractInformation as u8 => {
+                Ok(ResponseType::ContractInformation)
+            }
+            x if x == ResponseType::AccountInformation as u8 => {
+                Ok(ResponseType::AccountInformation)
+            }
+            x if x == ResponseType::PackageWithProof as u8 => Ok(ResponseType::PackageWithProof),
+            x if x == ResponseType::AddressableEntityInformation as u8 => {
+                Ok(ResponseType::AddressableEntityInformation)
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<ResponseType> for u8 {
+    fn from(value: ResponseType) -> Self {
+        value as u8
+    }
+}
+
+impl fmt::Display for ResponseType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ResponseType::BlockHeaderV1 => write!(f, "BlockHeaderV1"),
+            ResponseType::BlockHeader => write!(f, "BlockHeader"),
+            ResponseType::BlockBodyV1 => write!(f, "BlockBodyV1"),
+            ResponseType::BlockBody => write!(f, "BlockBody"),
+            ResponseType::ApprovalsHashesV1 => write!(f, "ApprovalsHashesV1"),
+            ResponseType::ApprovalsHashes => write!(f, "ApprovalsHashes"),
+            ResponseType::BlockSignaturesV1 => write!(f, "BlockSignaturesV1"),
+            ResponseType::BlockSignatures => write!(f, "BlockSignatures"),
+            ResponseType::Deploy => write!(f, "Deploy"),
+            ResponseType::Transaction => write!(f, "Transaction"),
+            ResponseType::ExecutionResultV1 => write!(f, "ExecutionResultV1"),
+            ResponseType::ExecutionResult => write!(f, "ExecutionResult"),
+            ResponseType::Transfers => write!(f, "Transfers"),
+            ResponseType::FinalizedDeployApprovals => write!(f, "FinalizedDeployApprovals"),
+            ResponseType::FinalizedApprovals => write!(f, "FinalizedApprovals"),
+            ResponseType::SignedBlock => write!(f, "SignedBlock"),
+            ResponseType::TransactionWithExecutionInfo => write!(f, "TransactionWithExecutionInfo"),
+            ResponseType::Peers => write!(f, "Peers"),
+            ResponseType::LastProgress => write!(f, "LastProgress"),
+            ResponseType::ReactorState => write!(f, "ReactorState"),
+            ResponseType::NetworkName => write!(f, "NetworkName"),
+            ResponseType::ConsensusValidatorChanges => write!(f, "ConsensusValidatorChanges"),
+            ResponseType::BlockSynchronizerStatus => write!(f, "BlockSynchronizerStatus"),
+            ResponseType::AvailableBlockRange => write!(f, "AvailableBlockRange"),
+            ResponseType::NextUpgrade => write!(f, "NextUpgrade"),
+            ResponseType::ConsensusStatus => write!(f, "ConsensusStatus"),
+            ResponseType::ChainspecRawBytes => write!(f, "ChainspecRawBytes"),
+            ResponseType::Uptime => write!(f, "Uptime"),
+            ResponseType::HighestBlockSequenceCheckResult => {
+                write!(f, "HighestBlockSequenceCheckResult")
+            }
+            ResponseType::SpeculativeExecutionResult => write!(f, "SpeculativeExecutionResult"),
+            ResponseType::GlobalStateQueryResult => write!(f, "GlobalStateQueryResult"),
+            ResponseType::StoredValues => write!(f, "StoredValues"),
+            ResponseType::GetTrieFullResult => write!(f, "GetTrieFullResult"),
+            ResponseType::NodeStatus => write!(f, "NodeStatus"),
+            ResponseType::WasmV1Result => write!(f, "WasmV1Result"),
+            ResponseType::DictionaryQueryResult => write!(f, "DictionaryQueryResult"),
+            ResponseType::BalanceResponse => write!(f, "BalanceResponse"),
+            ResponseType::Reward => write!(f, "Reward"),
+            ResponseType::ProtocolVersion => write!(f, "ProtocolVersion"),
+            ResponseType::ContractPackageWithProof => write!(f, "ContractPackageWithProof"),
+            ResponseType::ContractInformation => write!(f, "ContractInformation"),
+            ResponseType::AccountInformation => write!(f, "AccountInformation"),
+            ResponseType::PackageWithProof => write!(f, "PackageWithProof"),
+            ResponseType::AddressableEntityInformation => {
+                write!(f, "AddressableEntityInformation")
+            }
+        }
+    }
+}
+
+/// Represents an entity that can be sent as a payload.
+pub trait PayloadEntity {
+    /// Returns the payload type of the entity.
+    const RESPONSE_TYPE: ResponseType;
+}
+
+impl PayloadEntity for Transaction {
+    const RESPONSE_TYPE: ResponseType = ResponseType::Transaction;
+}
+
+impl PayloadEntity for Deploy {
+    const RESPONSE_TYPE: ResponseType = ResponseType::Deploy;
+}
+
+impl PayloadEntity for BlockHeader {
+    const RESPONSE_TYPE: ResponseType = ResponseType::BlockHeader;
+}
+
+impl PayloadEntity for BlockHeaderV1 {
+    const RESPONSE_TYPE: ResponseType = ResponseType::BlockHeaderV1;
+}
+
+impl PayloadEntity for BlockBody {
+    const RESPONSE_TYPE: ResponseType = ResponseType::BlockBody;
+}
+
+impl PayloadEntity for BlockBodyV1 {
+    const RESPONSE_TYPE: ResponseType = ResponseType::BlockBodyV1;
+}
+
+impl PayloadEntity for BlockSignatures {
+    const RESPONSE_TYPE: ResponseType = ResponseType::BlockSignatures;
+}
+
+impl PayloadEntity for BlockSignaturesV1 {
+    const RESPONSE_TYPE: ResponseType = ResponseType::BlockSignaturesV1;
+}
+
+impl PayloadEntity for ExecutionResult {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ExecutionResult;
+}
+
+impl PayloadEntity for ExecutionResultV1 {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ExecutionResultV1;
+}
+
+impl PayloadEntity for SignedBlock {
+    const RESPONSE_TYPE: ResponseType = ResponseType::SignedBlock;
+}
+
+impl PayloadEntity for TransactionWithExecutionInfo {
+    const RESPONSE_TYPE: ResponseType = ResponseType::TransactionWithExecutionInfo;
+}
+
+impl PayloadEntity for Peers {
+    const RESPONSE_TYPE: ResponseType = ResponseType::Peers;
+}
+
+impl PayloadEntity for Vec<Transfer> {
+    const RESPONSE_TYPE: ResponseType = ResponseType::Transfers;
+}
+
+impl PayloadEntity for AvailableBlockRange {
+    const RESPONSE_TYPE: ResponseType = ResponseType::AvailableBlockRange;
+}
+
+impl PayloadEntity for ChainspecRawBytes {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ChainspecRawBytes;
+}
+
+impl PayloadEntity for ConsensusValidatorChanges {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ConsensusValidatorChanges;
+}
+
+impl PayloadEntity for GlobalStateQueryResult {
+    const RESPONSE_TYPE: ResponseType = ResponseType::GlobalStateQueryResult;
+}
+
+impl PayloadEntity for DictionaryQueryResult {
+    const RESPONSE_TYPE: ResponseType = ResponseType::DictionaryQueryResult;
+}
+
+impl PayloadEntity for Vec<StoredValue> {
+    const RESPONSE_TYPE: ResponseType = ResponseType::StoredValues;
+}
+
+impl PayloadEntity for GetTrieFullResult {
+    const RESPONSE_TYPE: ResponseType = ResponseType::GetTrieFullResult;
+}
+
+impl PayloadEntity for SpeculativeExecutionResult {
+    const RESPONSE_TYPE: ResponseType = ResponseType::SpeculativeExecutionResult;
+}
+
+impl PayloadEntity for NodeStatus {
+    const RESPONSE_TYPE: ResponseType = ResponseType::NodeStatus;
+}
+
+impl PayloadEntity for NextUpgrade {
+    const RESPONSE_TYPE: ResponseType = ResponseType::NextUpgrade;
+}
+
+impl PayloadEntity for Uptime {
+    const RESPONSE_TYPE: ResponseType = ResponseType::Uptime;
+}
+
+impl PayloadEntity for LastProgress {
+    const RESPONSE_TYPE: ResponseType = ResponseType::LastProgress;
+}
+
+impl PayloadEntity for ReactorStateName {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ReactorState;
+}
+
+impl PayloadEntity for NetworkName {
+    const RESPONSE_TYPE: ResponseType = ResponseType::NetworkName;
+}
+
+impl PayloadEntity for BlockSynchronizerStatus {
+    const RESPONSE_TYPE: ResponseType = ResponseType::BlockSynchronizerStatus;
+}
+
+impl PayloadEntity for ConsensusStatus {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ConsensusStatus;
+}
+
+impl PayloadEntity for BalanceResponse {
+    const RESPONSE_TYPE: ResponseType = ResponseType::BalanceResponse;
+}
+
+impl PayloadEntity for RewardResponse {
+    const RESPONSE_TYPE: ResponseType = ResponseType::Reward;
+}
+
+impl PayloadEntity for ProtocolVersion {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ProtocolVersion;
+}
+
+impl PayloadEntity for ValueWithProof<ContractPackage> {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ContractPackageWithProof;
+}
+
+impl PayloadEntity for ContractInformation {
+    const RESPONSE_TYPE: ResponseType = ResponseType::ContractInformation;
+}
+
+impl PayloadEntity for AccountInformation {
+    const RESPONSE_TYPE: ResponseType = ResponseType::AccountInformation;
+}
+
+impl PayloadEntity for ValueWithProof<Package> {
+    const RESPONSE_TYPE: ResponseType = ResponseType::PackageWithProof;
+}
+
+impl PayloadEntity for AddressableEntityInformation {
+    const RESPONSE_TYPE: ResponseType = ResponseType::AddressableEntityInformation;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn convert_u8_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = ResponseType::random(rng);
+        assert_eq!(ResponseType::try_from(val as u8), Ok(val));
+    }
+}

--- a/binary_port/src/speculative_execution_result.rs
+++ b/binary_port/src/speculative_execution_result.rs
@@ -1,0 +1,182 @@
+use once_cell::sync::Lazy;
+#[cfg(any(feature = "testing", test))]
+use rand::Rng;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[cfg(any(feature = "testing", test))]
+use rand::distributions::{Alphanumeric, DistString};
+
+#[cfg(any(feature = "testing", test))]
+use casper_types::testing::TestRng;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    contract_messages::Messages,
+    execution::Effects,
+    BlockHash, Digest, Gas, InvalidTransaction, Transfer,
+};
+
+static SPECULATIVE_EXECUTION_RESULT: Lazy<SpeculativeExecutionResult> = Lazy::new(|| {
+    SpeculativeExecutionResult::new(
+        BlockHash::new(Digest::from([0; Digest::LENGTH])),
+        vec![],
+        Gas::zero(),
+        Gas::zero(),
+        Effects::new(),
+        Messages::new(),
+        None,
+    )
+});
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SpeculativeExecutionResult {
+    /// Block hash against which the execution was performed.
+    block_hash: BlockHash,
+    /// List of transfers that happened during execution.
+    transfers: Vec<Transfer>,
+    /// Gas limit.
+    limit: Gas,
+    /// Gas consumed.
+    consumed: Gas,
+    /// Execution effects.
+    effects: Effects,
+    /// Messages emitted during execution.
+    messages: Messages,
+    /// Did the wasm execute successfully?
+    error: Option<String>,
+}
+
+impl SpeculativeExecutionResult {
+    pub fn new(
+        block_hash: BlockHash,
+        transfers: Vec<Transfer>,
+        limit: Gas,
+        consumed: Gas,
+        effects: Effects,
+        messages: Messages,
+        error: Option<String>,
+    ) -> Self {
+        SpeculativeExecutionResult {
+            transfers,
+            limit,
+            consumed,
+            effects,
+            messages,
+            error,
+            block_hash,
+        }
+    }
+
+    // This method is not intended to be used by third party crates.
+    #[doc(hidden)]
+    pub fn example() -> &'static Self {
+        &SPECULATIVE_EXECUTION_RESULT
+    }
+
+    #[cfg(any(feature = "testing", test))]
+    pub fn random(rng: &mut TestRng) -> Self {
+        use casper_types::contract_messages::Message;
+
+        let random_messages = |rng: &mut TestRng| -> Messages {
+            let count = rng.gen_range(16..128);
+            std::iter::repeat_with(|| Message::random(rng))
+                .take(count)
+                .collect()
+        };
+
+        SpeculativeExecutionResult {
+            block_hash: BlockHash::new(rng.gen()),
+            transfers: vec![Transfer::random(rng)],
+            limit: Gas::random(rng),
+            consumed: Gas::random(rng),
+            effects: Effects::random(rng),
+            messages: random_messages(rng),
+            error: if rng.gen() {
+                None
+            } else {
+                let count = rng.gen_range(16..128);
+                Some(Alphanumeric.sample_string(rng, count))
+            },
+        }
+    }
+}
+
+impl From<InvalidTransaction> for SpeculativeExecutionResult {
+    fn from(invalid_transaction: InvalidTransaction) -> Self {
+        SpeculativeExecutionResult {
+            transfers: Default::default(),
+            limit: Default::default(),
+            consumed: Default::default(),
+            effects: Default::default(),
+            messages: Default::default(),
+            error: Some(format!("{}", invalid_transaction)),
+            block_hash: Default::default(),
+        }
+    }
+}
+
+impl ToBytes for SpeculativeExecutionResult {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        ToBytes::serialized_length(&self.transfers)
+            + ToBytes::serialized_length(&self.limit)
+            + ToBytes::serialized_length(&self.consumed)
+            + ToBytes::serialized_length(&self.effects)
+            + ToBytes::serialized_length(&self.messages)
+            + ToBytes::serialized_length(&self.error)
+            + ToBytes::serialized_length(&self.block_hash)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.transfers.write_bytes(writer)?;
+        self.limit.write_bytes(writer)?;
+        self.consumed.write_bytes(writer)?;
+        self.effects.write_bytes(writer)?;
+        self.messages.write_bytes(writer)?;
+        self.error.write_bytes(writer)?;
+        self.block_hash.write_bytes(writer)
+    }
+}
+
+impl FromBytes for SpeculativeExecutionResult {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (transfers, bytes) = Vec::<Transfer>::from_bytes(bytes)?;
+        let (limit, bytes) = Gas::from_bytes(bytes)?;
+        let (consumed, bytes) = Gas::from_bytes(bytes)?;
+        let (effects, bytes) = Effects::from_bytes(bytes)?;
+        let (messages, bytes) = Messages::from_bytes(bytes)?;
+        let (error, bytes) = Option::<String>::from_bytes(bytes)?;
+        let (block_hash, bytes) = BlockHash::from_bytes(bytes)?;
+        Ok((
+            SpeculativeExecutionResult {
+                transfers,
+                limit,
+                consumed,
+                effects,
+                messages,
+                error,
+                block_hash,
+            },
+            bytes,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = SpeculativeExecutionResult::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/state_request.rs
+++ b/binary_port/src/state_request.rs
@@ -1,0 +1,118 @@
+use std::fmt::{Display, Formatter, Result as DisplayResult};
+
+use crate::GlobalStateEntityQualifier;
+#[cfg(test)]
+use casper_types::testing::TestRng;
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    GlobalStateIdentifier,
+};
+#[cfg(test)]
+use rand::Rng;
+
+/// A request to get data from the global state.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlobalStateRequest {
+    /// Global state identifier, `None` means "latest block state".
+    state_identifier: Option<GlobalStateIdentifier>,
+    /// qualifier that points to a specific item (or items) in the global state.
+    qualifier: GlobalStateEntityQualifier,
+}
+
+impl GlobalStateRequest {
+    pub fn new(
+        state_identifier: Option<GlobalStateIdentifier>,
+        qualifier: GlobalStateEntityQualifier,
+    ) -> Self {
+        GlobalStateRequest {
+            state_identifier,
+            qualifier,
+        }
+    }
+    pub fn destructure(self) -> (Option<GlobalStateIdentifier>, GlobalStateEntityQualifier) {
+        (self.state_identifier, self.qualifier)
+    }
+
+    pub fn state_identifier(self) -> Option<GlobalStateIdentifier> {
+        self.state_identifier
+    }
+
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        let state_identifier = rng
+            .gen::<bool>()
+            .then(|| GlobalStateIdentifier::random(rng));
+        let qualifier = GlobalStateEntityQualifier::random(rng);
+        Self {
+            state_identifier,
+            qualifier,
+        }
+    }
+}
+
+impl ToBytes for GlobalStateRequest {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.state_identifier.write_bytes(writer)?;
+        self.qualifier.write_bytes(writer)?;
+        Ok(())
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.state_identifier.serialized_length() + self.qualifier.serialized_length()
+    }
+}
+
+impl FromBytes for GlobalStateRequest {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (state_identifier, remainder) = FromBytes::from_bytes(bytes)?;
+        let (qualifier, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((
+            GlobalStateRequest {
+                state_identifier,
+                qualifier,
+            },
+            remainder,
+        ))
+    }
+}
+
+impl Display for GlobalStateRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> DisplayResult {
+        match self.qualifier {
+            GlobalStateEntityQualifier::Item { base_key, .. } => {
+                write!(f, "get item from global state ({})", base_key)
+            }
+            GlobalStateEntityQualifier::AllItems { key_tag, .. } => {
+                write!(f, "get all items ({})", key_tag)
+            }
+            GlobalStateEntityQualifier::DictionaryItem { .. } => {
+                write!(f, "get dictionary item")
+            }
+            GlobalStateEntityQualifier::Balance { .. } => {
+                write!(f, "get balance by state root",)
+            }
+            GlobalStateEntityQualifier::ItemsByPrefix { .. } => {
+                write!(f, "get items by prefix")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+        let val = GlobalStateRequest::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/type_wrappers.rs
+++ b/binary_port/src/type_wrappers.rs
@@ -1,0 +1,835 @@
+use core::{convert::TryFrom, num::TryFromIntError, time::Duration};
+use std::collections::BTreeMap;
+
+use casper_types::{
+    bytesrepr::{self, Bytes, FromBytes, ToBytes},
+    contracts::ContractHash,
+    global_state::TrieMerkleProof,
+    system::auction::DelegationRate,
+    Account, AddressableEntity, BlockHash, ByteCode, Contract, ContractWasm, EntityAddr, EraId,
+    ExecutionInfo, Key, PublicKey, StoredValue, TimeDiff, Timestamp, Transaction, ValidatorChange,
+    U512,
+};
+use serde::Serialize;
+
+use super::GlobalStateQueryResult;
+
+// `bytesrepr` implementations for type wrappers are repetitive, hence this macro helper. We should
+// get rid of this after we introduce the proper "bytesrepr-derive" proc macro.
+macro_rules! impl_bytesrepr_for_type_wrapper {
+    ($t:ident) => {
+        impl ToBytes for $t {
+            fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+                self.0.to_bytes()
+            }
+
+            fn serialized_length(&self) -> usize {
+                self.0.serialized_length()
+            }
+
+            fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+                self.0.write_bytes(writer)
+            }
+        }
+
+        impl FromBytes for $t {
+            fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+                let (inner, remainder) = FromBytes::from_bytes(bytes)?;
+                Ok(($t(inner), remainder))
+            }
+        }
+    };
+}
+
+/// Type representing uptime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct Uptime(u64);
+
+impl Uptime {
+    /// Constructs new uptime.
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Retrieve the inner value.
+    pub fn into_inner(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<Uptime> for Duration {
+    fn from(uptime: Uptime) -> Self {
+        Duration::from_secs(uptime.0)
+    }
+}
+
+impl TryFrom<Uptime> for TimeDiff {
+    type Error = TryFromIntError;
+
+    fn try_from(uptime: Uptime) -> Result<Self, Self::Error> {
+        u32::try_from(uptime.0).map(TimeDiff::from_seconds)
+    }
+}
+
+/// Type representing changes in consensus validators.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct ConsensusValidatorChanges(BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>>);
+
+impl ConsensusValidatorChanges {
+    /// Constructs new consensus validator changes.
+    pub fn new(value: BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>>) -> Self {
+        Self(value)
+    }
+
+    /// Retrieve the inner value.
+    pub fn into_inner(self) -> BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>> {
+        self.0
+    }
+}
+
+impl From<ConsensusValidatorChanges> for BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>> {
+    fn from(consensus_validator_changes: ConsensusValidatorChanges) -> Self {
+        consensus_validator_changes.0
+    }
+}
+
+/// Type representing network name.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct NetworkName(String);
+
+impl NetworkName {
+    /// Constructs new network name.
+    pub fn new(value: impl ToString) -> Self {
+        Self(value.to_string())
+    }
+
+    /// Retrieve the inner value.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl From<NetworkName> for String {
+    fn from(network_name: NetworkName) -> Self {
+        network_name.0
+    }
+}
+
+/// Type representing the reactor state name.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct ReactorStateName(String);
+
+impl ReactorStateName {
+    /// Constructs new reactor state name.
+    pub fn new(value: impl ToString) -> Self {
+        Self(value.to_string())
+    }
+
+    /// Retrieve the name as a `String`.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl From<ReactorStateName> for String {
+    fn from(reactor_state: ReactorStateName) -> Self {
+        reactor_state.0
+    }
+}
+
+/// Type representing last progress of the sync process.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct LastProgress(Timestamp);
+
+impl LastProgress {
+    /// Constructs new last progress.
+    pub fn new(value: Timestamp) -> Self {
+        Self(value)
+    }
+
+    /// Retrieve the inner value.
+    pub fn into_inner(self) -> Timestamp {
+        self.0
+    }
+}
+
+impl From<LastProgress> for Timestamp {
+    fn from(last_progress: LastProgress) -> Self {
+        last_progress.0
+    }
+}
+
+/// Type representing results of the get full trie request.
+#[derive(Debug, PartialEq, Eq)]
+pub struct GetTrieFullResult(Option<Bytes>);
+
+impl GetTrieFullResult {
+    /// Constructs new get trie result.
+    pub fn new(value: Option<Bytes>) -> Self {
+        Self(value)
+    }
+
+    /// Returns the inner value.
+    pub fn into_inner(self) -> Option<Bytes> {
+        self.0
+    }
+}
+
+/// Type representing the reward of a validator or a delegator.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct RewardResponse {
+    amount: U512,
+    era_id: EraId,
+    delegation_rate: DelegationRate,
+    switch_block_hash: BlockHash,
+}
+
+impl RewardResponse {
+    /// Constructs new reward response.
+    pub fn new(
+        amount: U512,
+        era_id: EraId,
+        delegation_rate: DelegationRate,
+        switch_block_hash: BlockHash,
+    ) -> Self {
+        Self {
+            amount,
+            era_id,
+            delegation_rate,
+            switch_block_hash,
+        }
+    }
+
+    /// Returns the amount of the reward.
+    pub fn amount(&self) -> U512 {
+        self.amount
+    }
+
+    /// Returns the era ID.
+    pub fn era_id(&self) -> EraId {
+        self.era_id
+    }
+
+    /// Returns the delegation rate of the validator.
+    pub fn delegation_rate(&self) -> DelegationRate {
+        self.delegation_rate
+    }
+
+    /// Returns the switch block hash at which the reward was distributed.
+    pub fn switch_block_hash(&self) -> BlockHash {
+        self.switch_block_hash
+    }
+}
+
+impl ToBytes for RewardResponse {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.amount.serialized_length()
+            + self.era_id.serialized_length()
+            + self.delegation_rate.serialized_length()
+            + self.switch_block_hash.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.amount.write_bytes(writer)?;
+        self.era_id.write_bytes(writer)?;
+        self.delegation_rate.write_bytes(writer)?;
+        self.switch_block_hash.write_bytes(writer)
+    }
+}
+
+impl FromBytes for RewardResponse {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (amount, remainder) = FromBytes::from_bytes(bytes)?;
+        let (era_id, remainder) = FromBytes::from_bytes(remainder)?;
+        let (delegation_rate, remainder) = FromBytes::from_bytes(remainder)?;
+        let (switch_block_hash, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((
+            RewardResponse::new(amount, era_id, delegation_rate, switch_block_hash),
+            remainder,
+        ))
+    }
+}
+
+/// Describes the consensus status.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct ConsensusStatus {
+    validator_public_key: PublicKey,
+    round_length: Option<TimeDiff>,
+}
+
+impl ConsensusStatus {
+    /// Constructs new consensus status.
+    pub fn new(validator_public_key: PublicKey, round_length: Option<TimeDiff>) -> Self {
+        Self {
+            validator_public_key,
+            round_length,
+        }
+    }
+
+    #[allow(dead_code)]
+    /// Returns the validator public key.
+    pub fn validator_public_key(&self) -> &PublicKey {
+        &self.validator_public_key
+    }
+
+    #[allow(dead_code)]
+    /// Returns the round length.
+    pub fn round_length(&self) -> Option<TimeDiff> {
+        self.round_length
+    }
+}
+
+impl ToBytes for ConsensusStatus {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.validator_public_key.serialized_length() + self.round_length.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.validator_public_key.write_bytes(writer)?;
+        self.round_length.write_bytes(writer)
+    }
+}
+
+impl FromBytes for ConsensusStatus {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (validator_public_key, remainder) = FromBytes::from_bytes(bytes)?;
+        let (round_length, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((
+            ConsensusStatus::new(validator_public_key, round_length),
+            remainder,
+        ))
+    }
+}
+
+/// A transaction with execution info.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct TransactionWithExecutionInfo {
+    transaction: Transaction,
+    execution_info: Option<ExecutionInfo>,
+}
+
+impl TransactionWithExecutionInfo {
+    /// Constructs new transaction with execution info.
+    pub fn new(transaction: Transaction, execution_info: Option<ExecutionInfo>) -> Self {
+        Self {
+            transaction,
+            execution_info,
+        }
+    }
+
+    /// Converts `self` into the transaction and execution info.
+    pub fn into_inner(self) -> (Transaction, Option<ExecutionInfo>) {
+        (self.transaction, self.execution_info)
+    }
+}
+
+impl ToBytes for TransactionWithExecutionInfo {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.transaction.serialized_length() + self.execution_info.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.transaction.write_bytes(writer)?;
+        self.execution_info.write_bytes(writer)
+    }
+}
+
+impl FromBytes for TransactionWithExecutionInfo {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (transaction, remainder) = FromBytes::from_bytes(bytes)?;
+        let (execution_info, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((
+            TransactionWithExecutionInfo::new(transaction, execution_info),
+            remainder,
+        ))
+    }
+}
+
+/// A query result for a dictionary item, contains the dictionary item key and a global state query
+/// result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DictionaryQueryResult {
+    key: Key,
+    query_result: GlobalStateQueryResult,
+}
+
+impl DictionaryQueryResult {
+    /// Constructs new dictionary query result.
+    pub fn new(key: Key, query_result: GlobalStateQueryResult) -> Self {
+        Self { key, query_result }
+    }
+
+    /// Converts `self` into the dictionary item key and global state query result.
+    pub fn into_inner(self) -> (Key, GlobalStateQueryResult) {
+        (self.key, self.query_result)
+    }
+}
+
+impl ToBytes for DictionaryQueryResult {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.key.write_bytes(writer)?;
+        self.query_result.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.key.serialized_length() + self.query_result.serialized_length()
+    }
+}
+
+impl FromBytes for DictionaryQueryResult {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (key, remainder) = FromBytes::from_bytes(bytes)?;
+        let (query_result, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((DictionaryQueryResult::new(key, query_result), remainder))
+    }
+}
+
+/// An account with its associated merkle proof.
+#[derive(Debug, PartialEq)]
+pub struct AccountInformation {
+    account: Account,
+    merkle_proof: Vec<TrieMerkleProof<Key, StoredValue>>,
+}
+
+impl AccountInformation {
+    /// Constructs a new `AccountResponse`.
+    pub fn new(account: Account, merkle_proof: Vec<TrieMerkleProof<Key, StoredValue>>) -> Self {
+        Self {
+            account,
+            merkle_proof,
+        }
+    }
+
+    /// Returns the inner `Account`.
+    pub fn account(&self) -> &Account {
+        &self.account
+    }
+
+    /// Returns the merkle proof.
+    pub fn merkle_proof(&self) -> &Vec<TrieMerkleProof<Key, StoredValue>> {
+        &self.merkle_proof
+    }
+
+    /// Converts `self` into the account and merkle proof.
+    pub fn into_inner(self) -> (Account, Vec<TrieMerkleProof<Key, StoredValue>>) {
+        (self.account, self.merkle_proof)
+    }
+}
+
+impl ToBytes for AccountInformation {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.account.write_bytes(writer)?;
+        self.merkle_proof.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.account.serialized_length() + self.merkle_proof.serialized_length()
+    }
+}
+
+impl FromBytes for AccountInformation {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (account, remainder) = FromBytes::from_bytes(bytes)?;
+        let (merkle_proof, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((AccountInformation::new(account, merkle_proof), remainder))
+    }
+}
+
+/// A contract with its associated Wasm and merkle proof.
+#[derive(Debug, PartialEq)]
+pub struct ContractInformation {
+    hash: ContractHash,
+    contract: ValueWithProof<Contract>,
+    wasm: Option<ValueWithProof<ContractWasm>>,
+}
+
+impl ContractInformation {
+    /// Constructs new `ContractInformation`.
+    pub fn new(
+        hash: ContractHash,
+        contract: ValueWithProof<Contract>,
+        wasm: Option<ValueWithProof<ContractWasm>>,
+    ) -> Self {
+        Self {
+            hash,
+            contract,
+            wasm,
+        }
+    }
+
+    /// Returns the hash of the contract.
+    pub fn hash(&self) -> ContractHash {
+        self.hash
+    }
+
+    /// Returns the inner `Contract`.
+    pub fn contract(&self) -> &Contract {
+        &self.contract.value
+    }
+
+    /// Returns the Merkle proof of the contract.
+    pub fn contract_proof(&self) -> &Vec<TrieMerkleProof<Key, StoredValue>> {
+        &self.contract.merkle_proof
+    }
+
+    /// Returns the inner `ContractWasm` with its proof.
+    pub fn wasm(&self) -> Option<&ValueWithProof<ContractWasm>> {
+        self.wasm.as_ref()
+    }
+
+    /// Converts `self` into the contract hash, contract and Wasm.
+    pub fn into_inner(
+        self,
+    ) -> (
+        ContractHash,
+        ValueWithProof<Contract>,
+        Option<ValueWithProof<ContractWasm>>,
+    ) {
+        (self.hash, self.contract, self.wasm)
+    }
+}
+
+impl ToBytes for ContractInformation {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.hash.write_bytes(writer)?;
+        self.contract.write_bytes(writer)?;
+        self.wasm.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.hash.serialized_length()
+            + self.contract.serialized_length()
+            + self.wasm.serialized_length()
+    }
+}
+
+impl FromBytes for ContractInformation {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (hash, remainder) = FromBytes::from_bytes(bytes)?;
+        let (contract, remainder) = FromBytes::from_bytes(remainder)?;
+        let (wasm, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((ContractInformation::new(hash, contract, wasm), remainder))
+    }
+}
+
+/// A contract entity with its associated ByteCode.
+#[derive(Debug, PartialEq)]
+pub struct AddressableEntityInformation {
+    addr: EntityAddr,
+    entity: ValueWithProof<AddressableEntity>,
+    bytecode: Option<ValueWithProof<ByteCode>>,
+}
+
+impl AddressableEntityInformation {
+    /// Constructs new contract entity with ByteCode.
+    pub fn new(
+        addr: EntityAddr,
+        entity: ValueWithProof<AddressableEntity>,
+        bytecode: Option<ValueWithProof<ByteCode>>,
+    ) -> Self {
+        Self {
+            addr,
+            entity,
+            bytecode,
+        }
+    }
+
+    /// Returns the entity address.
+    pub fn addr(&self) -> EntityAddr {
+        self.addr
+    }
+
+    /// Returns the inner `AddressableEntity`.
+    pub fn entity(&self) -> &AddressableEntity {
+        &self.entity.value
+    }
+
+    /// Returns the inner `ByteCodeWithProof`.
+    pub fn entity_merkle_proof(&self) -> &Vec<TrieMerkleProof<Key, StoredValue>> {
+        &self.entity.merkle_proof
+    }
+
+    /// Returns the inner `ByteCode`.
+    pub fn bytecode(&self) -> Option<&ValueWithProof<ByteCode>> {
+        self.bytecode.as_ref()
+    }
+
+    /// Converts `self` into the entity address, entity and ByteCode.
+    pub fn into_inner(
+        self,
+    ) -> (
+        EntityAddr,
+        ValueWithProof<AddressableEntity>,
+        Option<ValueWithProof<ByteCode>>,
+    ) {
+        (self.addr, self.entity, self.bytecode)
+    }
+}
+
+impl ToBytes for AddressableEntityInformation {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.addr.write_bytes(writer)?;
+        self.entity.write_bytes(writer)?;
+        self.bytecode.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.addr.serialized_length()
+            + self.entity.serialized_length()
+            + self.bytecode.serialized_length()
+    }
+}
+
+impl FromBytes for AddressableEntityInformation {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (addr, remainder) = FromBytes::from_bytes(bytes)?;
+        let (entity, remainder) = FromBytes::from_bytes(remainder)?;
+        let (bytecode, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((
+            AddressableEntityInformation::new(addr, entity, bytecode),
+            remainder,
+        ))
+    }
+}
+
+/// A value with its associated Merkle proof.
+#[derive(Debug, PartialEq)]
+pub struct ValueWithProof<T> {
+    value: T,
+    merkle_proof: Vec<TrieMerkleProof<Key, StoredValue>>,
+}
+
+impl<T> ValueWithProof<T> {
+    /// Constructs a new `ValueWithProof`.
+    pub fn new(value: T, merkle_proof: Vec<TrieMerkleProof<Key, StoredValue>>) -> Self {
+        Self {
+            value,
+            merkle_proof,
+        }
+    }
+
+    /// Returns the value.
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    /// Returns the Merkle proof.
+    pub fn merkle_proof(&self) -> &[TrieMerkleProof<Key, StoredValue>] {
+        &self.merkle_proof
+    }
+
+    /// Converts `self` into the value and Merkle proof.
+    pub fn into_inner(self) -> (T, Vec<TrieMerkleProof<Key, StoredValue>>) {
+        (self.value, self.merkle_proof)
+    }
+}
+
+impl<T: ToBytes> ToBytes for ValueWithProof<T> {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.value.write_bytes(writer)?;
+        self.merkle_proof.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.value.serialized_length() + self.merkle_proof.serialized_length()
+    }
+}
+
+impl<T: FromBytes> FromBytes for ValueWithProof<T> {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (value, remainder) = FromBytes::from_bytes(bytes)?;
+        let (merkle_proof, remainder) = FromBytes::from_bytes(remainder)?;
+        Ok((ValueWithProof::new(value, merkle_proof), remainder))
+    }
+}
+
+impl_bytesrepr_for_type_wrapper!(Uptime);
+impl_bytesrepr_for_type_wrapper!(ConsensusValidatorChanges);
+impl_bytesrepr_for_type_wrapper!(NetworkName);
+impl_bytesrepr_for_type_wrapper!(ReactorStateName);
+impl_bytesrepr_for_type_wrapper!(LastProgress);
+impl_bytesrepr_for_type_wrapper!(GetTrieFullResult);
+
+#[cfg(test)]
+mod tests {
+    use core::iter::FromIterator;
+    use rand::Rng;
+
+    use super::*;
+    use casper_types::{
+        contracts::ContractPackageHash, execution::ExecutionResult, testing::TestRng, BlockHash,
+        CLValue, ContractWasmHash, StoredValue,
+    };
+
+    #[test]
+    fn uptime_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&Uptime::new(rng.gen()));
+    }
+
+    #[test]
+    fn consensus_validator_changes_roundtrip() {
+        let rng = &mut TestRng::new();
+        let map = BTreeMap::from_iter([(
+            PublicKey::random(rng),
+            vec![(EraId::random(rng), ValidatorChange::random(rng))],
+        )]);
+        bytesrepr::test_serialization_roundtrip(&ConsensusValidatorChanges::new(map));
+    }
+
+    #[test]
+    fn network_name_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&NetworkName::new(rng.random_string(5..20)));
+    }
+
+    #[test]
+    fn reactor_state_name_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&ReactorStateName::new(rng.random_string(5..20)));
+    }
+
+    #[test]
+    fn last_progress_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&LastProgress::new(Timestamp::random(rng)));
+    }
+
+    #[test]
+    fn get_trie_full_result_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&GetTrieFullResult::new(rng.gen()));
+    }
+
+    #[test]
+    fn reward_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&RewardResponse::new(
+            rng.gen(),
+            EraId::random(rng),
+            rng.gen(),
+            BlockHash::random(rng),
+        ));
+    }
+
+    #[test]
+    fn consensus_status_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&ConsensusStatus::new(
+            PublicKey::random(rng),
+            Some(TimeDiff::from_millis(rng.gen())),
+        ));
+    }
+
+    #[test]
+    fn transaction_with_execution_info_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&TransactionWithExecutionInfo::new(
+            Transaction::random(rng),
+            rng.gen::<bool>().then(|| ExecutionInfo {
+                block_hash: BlockHash::random(rng),
+                block_height: rng.gen(),
+                execution_result: rng.gen::<bool>().then(|| ExecutionResult::random(rng)),
+            }),
+        ));
+    }
+
+    #[test]
+    fn dictionary_query_result_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&DictionaryQueryResult::new(
+            Key::Account(rng.gen()),
+            GlobalStateQueryResult::new(
+                StoredValue::CLValue(CLValue::from_t(rng.gen::<i32>()).unwrap()),
+                vec![],
+            ),
+        ));
+    }
+
+    #[test]
+    fn contract_with_wasm_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&ContractInformation::new(
+            ContractHash::new(rng.gen()),
+            ValueWithProof::new(
+                Contract::new(
+                    ContractPackageHash::new(rng.gen()),
+                    ContractWasmHash::new(rng.gen()),
+                    Default::default(),
+                    Default::default(),
+                    Default::default(),
+                ),
+                Default::default(),
+            ),
+            rng.gen::<bool>().then(|| {
+                ValueWithProof::new(
+                    ContractWasm::new(rng.random_vec(10..50)),
+                    Default::default(),
+                )
+            }),
+        ));
+    }
+
+    #[test]
+    fn addressable_entity_with_byte_code_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&AddressableEntityInformation::new(
+            rng.gen(),
+            ValueWithProof::new(AddressableEntity::example().clone(), Default::default()),
+            rng.gen::<bool>().then(|| {
+                ValueWithProof::new(
+                    ByteCode::new(rng.gen(), rng.random_vec(10..50)),
+                    Default::default(),
+                )
+            }),
+        ));
+    }
+}

--- a/event_sidecar/Cargo.toml
+++ b/event_sidecar/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/casper-network/casper-sidecar/"
 repository = "https://github.com/casper-network/casper-sidecar/"
 
 [features]
-additional-metrics = ["casper-event-types/additional-metrics"]
+additional-metrics = ["casper-event-types/additional-metrics", "metrics/additional-metrics"]
 testing = []
 
 [dependencies]

--- a/event_sidecar/src/database/writer_generator.rs
+++ b/event_sidecar/src/database/writer_generator.rs
@@ -9,7 +9,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use casper_types::AsymmetricType;
 #[cfg(feature = "additional-metrics")]
-use casper_event_types::metrics;
+use metrics::db::DB_OPERATION_TIMES;
 use itertools::Itertools;
 use tokio::sync::Mutex;
 use $crate::{
@@ -469,7 +469,7 @@ async fn save_event_log(
 #[cfg(feature = "additional-metrics")]
 fn observe_db_operation_time(operation_name: &str, start: Instant) {
     let duration = start.elapsed();
-    metrics::DB_OPERATION_TIMES
+    DB_OPERATION_TIMES
         .with_label_values(&[operation_name])
         .observe(duration.as_nanos() as f64);
 }

--- a/event_sidecar/src/utils.rs
+++ b/event_sidecar/src/utils.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "additional-metrics")]
-use crate::metrics::EVENTS_PROCESSED_PER_SECOND;
+use metrics::db::EVENTS_PROCESSED_PER_SECOND;
 #[cfg(feature = "additional-metrics")]
 use std::sync::Arc;
 #[cfg(feature = "additional-metrics")]
@@ -136,7 +136,7 @@ pub fn start_metrics_thread(module_name: String) -> Sender<()> {
     let metrics_data_for_thread = metrics_data.clone();
     tokio::spawn(async move {
         let metrics_data = metrics_data_for_thread;
-        while let Some(_) = metrics_queue_rx.recv().await {
+        while metrics_queue_rx.recv().await.is_some() {
             let mut guard = metrics_data.lock().await;
             guard.observed_events += 1;
             drop(guard);

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -13,3 +13,6 @@ repository = "https://github.com/casper-network/casper-sidecar/"
 [dependencies]
 once_cell = { workspace = true }
 prometheus = { version = "0.13.3", features = ["process"] }
+
+[features]
+additional-metrics = []

--- a/metrics/src/db.rs
+++ b/metrics/src/db.rs
@@ -1,5 +1,7 @@
 use super::REGISTRY;
 use once_cell::sync::Lazy;
+#[cfg(feature = "additional-metrics")]
+use prometheus::GaugeVec;
 use prometheus::{HistogramOpts, HistogramVec, Opts};
 
 const RAW_DATA_SIZE_BUCKETS: &[f64; 8] = &[

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Types for casper-event-listener library"
 license-file = "../LICENSE"
 documentation = "README.md"
-homepage = "https://github.com/casper-network/casper-sidecar/" 
+homepage = "https://github.com/casper-network/casper-sidecar/"
 repository = "https://github.com/casper-network/casper-sidecar/"
 
 [dependencies]


### PR DESCRIPTION
Copy required types from `casper-node/binary-port` to remove dependency on node repo.

Closes https://github.com/casper-network/casper-sidecar/issues/350