### PR TITLE
Make IP & port config consistent across all node connections

### DIFF
--- a/resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
@@ -1,19 +1,22 @@
 [rpc_server.main_server]
 enable_server = true
-address = "0.0.0.0:11102"
+ip_address = "0.0.0.0"
+port = 11102
 qps_limit = 100
 max_body_bytes = 2621440
 cors_origin = ""
 
 [rpc_server.speculative_exec_server]
 enable_server = true
-address = "0.0.0.0:25102"
+ip_address = "0.0.0.0"
+port = 25102
 qps_limit = 1
 max_body_bytes = 2621440
 cors_origin = ""
 
 [rpc_server.node_client]
-address = "0.0.0.0:28102"
+ip_address = "0.0.0.0"
+port = 28102
 max_message_size_bytes = 4194304
 request_limit = 3
 request_buffer_size = 16

--- a/resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml
@@ -1,19 +1,22 @@
 [rpc_server.main_server]
 enable_server = true
-address = "0.0.0.0:11102"
+ip_address = "0.0.0.0"
+port = 11102
 qps_limit = 100
 max_body_bytes = 2621440
 cors_origin = ""
 
 [rpc_server.speculative_exec_server]
 enable_server = true
-address = "0.0.0.0:25102"
+ip_address = "0.0.0.0"
+port = 25102
 qps_limit = 1
 max_body_bytes = 2621440
 cors_origin = ""
 
 [rpc_server.node_client]
-address = "0.0.0.0:28102"
+ip_address = "0.0.0.0"
+port = 28102
 max_message_size_bytes = 4194304
 request_limit = 3
 request_buffer_size = 16

--- a/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
@@ -1,19 +1,22 @@
 [rpc_server.main_server]
 enable_server = true
-address = "0.0.0.0:7777"
+ip_address = "0.0.0.0"
+port = 7777
 qps_limit = 100
 max_body_bytes = 2621440
 cors_origin = ""
 
 [rpc_server.speculative_exec_server]
 enable_server = true
-address = "0.0.0.0:7778"
+ip_address = "0.0.0.0"
+port = 7778
 qps_limit = 1
 max_body_bytes = 2621440
 cors_origin = ""
 
 [rpc_server.node_client]
-address = "3.20.57.210:7777"
+ip_address = "3.20.57.210"
+port = 7777
 max_message_size_bytes = 4194304
 request_limit = 10
 request_buffer_size = 50

--- a/resources/example_configs/default_debian_config.toml
+++ b/resources/example_configs/default_debian_config.toml
@@ -11,7 +11,8 @@ enable_server = true
 # the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
 #
 # The actual bound address will be reported via a log line if logging is enabled.
-address = '0.0.0.0:7777'
+ip_address = '0.0.0.0'
+port= 7777
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
@@ -44,7 +45,8 @@ enable_server = true
 # but the node will be otherwise unaffected.
 #
 # The actual bound address will be reported via a log line if logging is enabled.
-address = '0.0.0.0:7778'
+ip_address = '0.0.0.0'
+port = 7778
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
@@ -65,7 +67,8 @@ cors_origin = ''
 # =========================================
 [rpc_server.node_client]
 # The address of the node to connect to.
-address = '127.0.0.1:7779'
+ip_address = '127.0.0.1'
+port = 7779
 # Maximum size of a message in bytes.
 max_message_size_bytes = 4_194_304
 # Maximum number of in-flight node requests.

--- a/resources/example_configs/default_rpc_only_config.toml
+++ b/resources/example_configs/default_rpc_only_config.toml
@@ -11,7 +11,8 @@ enable_server = true
 # the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
 #
 # The actual bound address will be reported via a log line if logging is enabled.
-address = '0.0.0.0:7777'
+ip_address = '0.0.0.0'
+port = 7777
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
@@ -44,7 +45,8 @@ enable_server = true
 # but the node will be otherwise unaffected.
 #
 # The actual bound address will be reported via a log line if logging is enabled.
-address = '0.0.0.0:7778'
+ip_address = '0.0.0.0'
+port = 7778
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
@@ -65,7 +67,8 @@ cors_origin = ''
 # =========================================
 [rpc_server.node_client]
 # The address of the node to connect to.
-address = '127.0.0.1:7779'
+ip_address = '127.0.0.1'
+port = 7779
 # Maximum size of a message in bytes.
 max_message_size_bytes = 4_194_304
 # Maximum number of in-flight node requests.

--- a/rpc_sidecar/src/lib.rs
+++ b/rpc_sidecar/src/lib.rs
@@ -70,7 +70,7 @@ async fn retype_future_vec(
 async fn run_rpc(config: RpcConfig, node_client: Arc<dyn NodeClient>) -> Result<(), Error> {
     run_rpc_server(
         node_client,
-        start_listening(&config.address)?,
+        start_listening(&SocketAddr::new(config.ip_address, config.port))?,
         config.qps_limit,
         config.max_body_bytes,
         config.cors_origin.clone(),
@@ -85,7 +85,7 @@ async fn run_speculative_exec(
 ) -> anyhow::Result<()> {
     run_speculative_exec_server(
         node_client,
-        start_listening(&config.address)?,
+        start_listening(&SocketAddr::new(config.ip_address, config.port))?,
         config.qps_limit,
         config.max_body_bytes,
         config.cors_origin.clone(),

--- a/rpc_sidecar/src/speculative_exec_config.rs
+++ b/rpc_sidecar/src/speculative_exec_config.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr};
 
 use datasize::DataSize;
 use serde::Deserialize;
@@ -6,7 +6,8 @@ use serde::Deserialize;
 /// Default binding address for the speculative execution RPC HTTP server.
 ///
 /// Uses a fixed port per node, but binds on any interface.
-const DEFAULT_ADDRESS: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 1);
+const DEFAULT_IP_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+const DEFAULT_PORT: u16 = 1;
 /// Default rate limit in qps.
 const DEFAULT_QPS_LIMIT: u64 = 1;
 /// Default max body bytes (2.5MB).
@@ -21,8 +22,10 @@ const DEFAULT_CORS_ORIGIN: &str = "";
 pub struct Config {
     /// Setting to enable the HTTP server.
     pub enable_server: bool,
-    /// Address to bind JSON-RPC speculative execution server to.
-    pub address: SocketAddr,
+    /// IP address to bind JSON-RPC speculative execution server to.
+    pub ip_address: IpAddr,
+    /// Port to bind JSON-RPC speculative execution server to.
+    pub port: u16,
     /// Maximum rate limit in queries per second.
     pub qps_limit: u64,
     /// Maximum number of bytes to accept in a single request body.
@@ -36,7 +39,8 @@ impl Config {
     pub fn new() -> Self {
         Config {
             enable_server: false,
-            address: DEFAULT_ADDRESS,
+            ip_address: DEFAULT_IP_ADDRESS,
+            port: DEFAULT_PORT,
             qps_limit: DEFAULT_QPS_LIMIT,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             cors_origin: DEFAULT_CORS_ORIGIN.to_string(),

--- a/sidecar/src/component.rs
+++ b/sidecar/src/component.rs
@@ -245,7 +245,7 @@ impl Component for RpcApiComponent {
 #[cfg(test)]
 mod tests {
     use std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::{IpAddr, Ipv4Addr},
         sync::Arc,
     };
 
@@ -382,16 +382,21 @@ mod tests {
         let mut config = all_components_all_enabled();
         config.rpc_server.as_mut().unwrap().node_client =
             NodeClientConfig::new_with_port_and_retries(port, 1);
-        config.rpc_server.as_mut().unwrap().main_server.address =
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-        config
+
+        let main_server_config = &mut config.rpc_server.as_mut().unwrap().main_server;
+        main_server_config.ip_address = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+        main_server_config.port = port;
+
+        let speculative_exec_server_config = config
             .rpc_server
             .as_mut()
             .unwrap()
             .speculative_exec_server
             .as_mut()
-            .unwrap()
-            .address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
+            .unwrap();
+        speculative_exec_server_config.ip_address = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+        speculative_exec_server_config.port = port;
+
         let res = component.prepare_component_task(&config).await;
         assert!(res.is_ok());
         assert!(res.unwrap().is_some());


### PR DESCRIPTION
Make sure that whenever a node connection is configured in config files IP address and TCP port are separate fields.