### PR TITLE
Rename SignedBlock to BlockWithSignatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "serde",
  "version_check",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytecount"
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "casper-binary-port"
 version = "1.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=dev#83ab415edd779746477f77c5d6daf1ec9525f965"
+source = "git+https://github.com/casper-network/casper-node.git?branch=dev#15ef9a9a36ddfe8184d4d22040d6a95db02dd32b"
 dependencies = [
  "bincode",
  "bytes",
@@ -699,7 +699,7 @@ dependencies = [
 [[package]]
 name = "casper-types"
 version = "5.0.0"
-source = "git+https://github.com/casper-network/casper-node.git?branch=dev#83ab415edd779746477f77c5d6daf1ec9525f965"
+source = "git+https://github.com/casper-network/casper-node.git?branch=dev#15ef9a9a36ddfe8184d4d22040d6a95db02dd32b"
 dependencies = [
  "base16",
  "base64 0.13.1",
@@ -710,7 +710,7 @@ dependencies = [
  "derive_more",
  "derp",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "hex_fmt",
  "humantime",
@@ -1609,8 +1609,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2358,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -2400,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2427,7 +2439,7 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.21",
  "rustls-pki-types",
@@ -2457,7 +2469,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2476,7 +2488,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2739,7 +2751,7 @@ dependencies = [
  "clap",
  "fancy-regex 0.11.0",
  "fraction 0.13.1",
- "getrandom",
+ "getrandom 0.2.15",
  "iso8601",
  "itoa",
  "memchr",
@@ -2973,7 +2985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3017,7 +3029,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rand",
@@ -3705,7 +3717,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3741,7 +3753,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3879,7 +3891,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -3928,7 +3940,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted 0.9.0",
@@ -4061,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -4106,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -4293,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap 2.7.1",
  "itoa",
@@ -4883,13 +4895,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -5325,9 +5337,9 @@ checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-normalization"
@@ -5598,6 +5610,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasite"
@@ -5932,9 +5953,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
 ]
@@ -5947,6 +5968,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -33,9 +33,9 @@ use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
     contracts::ContractPackage,
     system::auction::DelegatorKind,
-    AvailableBlockRange, BlockHash, BlockHeader, BlockIdentifier, ChainspecRawBytes, Digest,
-    GlobalStateIdentifier, Key, KeyTag, Package, Peers, ProtocolVersion, PublicKey, BlockWithSignatures,
-    StoredValue, Transaction, TransactionHash, Transfer,
+    AvailableBlockRange, BlockHash, BlockHeader, BlockIdentifier, BlockWithSignatures,
+    ChainspecRawBytes, Digest, GlobalStateIdentifier, Key, KeyTag, Package, Peers, ProtocolVersion,
+    PublicKey, StoredValue, Transaction, TransactionHash, Transfer,
 };
 use std::{
     fmt::{self, Display, Formatter},

--- a/rpc_sidecar/src/node_client.rs
+++ b/rpc_sidecar/src/node_client.rs
@@ -34,7 +34,7 @@ use casper_types::{
     contracts::ContractPackage,
     system::auction::DelegatorKind,
     AvailableBlockRange, BlockHash, BlockHeader, BlockIdentifier, ChainspecRawBytes, Digest,
-    GlobalStateIdentifier, Key, KeyTag, Package, Peers, ProtocolVersion, PublicKey, SignedBlock,
+    GlobalStateIdentifier, Key, KeyTag, Package, Peers, ProtocolVersion, PublicKey, BlockWithSignatures,
     StoredValue, Transaction, TransactionHash, Transfer,
 };
 use std::{
@@ -194,14 +194,14 @@ pub trait NodeClient: Send + Sync {
         parse_response::<BlockHeader>(&resp.into())
     }
 
-    async fn read_signed_block(
+    async fn read_block_with_signatures(
         &self,
         block_identifier: Option<BlockIdentifier>,
-    ) -> Result<Option<SignedBlock>, Error> {
+    ) -> Result<Option<BlockWithSignatures>, Error> {
         let resp = self
-            .read_info(InformationRequest::SignedBlock(block_identifier))
+            .read_info(InformationRequest::BlockWithSignatures(block_identifier))
             .await?;
-        parse_response::<SignedBlock>(&resp.into())
+        parse_response::<BlockWithSignatures>(&resp.into())
     }
 
     async fn read_transaction_with_execution_info(

--- a/rpc_sidecar/src/rpcs/chain.rs
+++ b/rpc_sidecar/src/rpcs/chain.rs
@@ -411,8 +411,8 @@ mod tests {
     use casper_types::{
         system::auction::{DelegatorKind, EraInfo, SeigniorageAllocation},
         testing::TestRng,
-        AsymmetricType, Block, BlockSignaturesV1, BlockSignaturesV2, ChainNameDigest, PublicKey,
-        BlockWithSignatures, TestBlockBuilder, TestBlockV1Builder, U512,
+        AsymmetricType, Block, BlockSignaturesV1, BlockSignaturesV2, BlockWithSignatures,
+        ChainNameDigest, PublicKey, TestBlockBuilder, TestBlockV1Builder, U512,
     };
     use pretty_assertions::assert_eq;
     use rand::Rng;

--- a/rpc_sidecar/src/rpcs/chain.rs
+++ b/rpc_sidecar/src/rpcs/chain.rs
@@ -108,7 +108,7 @@ impl RpcWithOptionalParams for GetBlock {
         maybe_params: Option<Self::OptionalRequestParams>,
     ) -> Result<Self::ResponseResult, RpcError> {
         let identifier = maybe_params.map(|params| params.block_identifier);
-        let (block, signatures) = common::get_signed_block(&*node_client, identifier)
+        let (block, signatures) = common::get_block_with_signatures(&*node_client, identifier)
             .await?
             .into_inner();
         Ok(Self::ResponseResult {
@@ -412,7 +412,7 @@ mod tests {
         system::auction::{DelegatorKind, EraInfo, SeigniorageAllocation},
         testing::TestRng,
         AsymmetricType, Block, BlockSignaturesV1, BlockSignaturesV2, ChainNameDigest, PublicKey,
-        SignedBlock, TestBlockBuilder, TestBlockV1Builder, U512,
+        BlockWithSignatures, TestBlockBuilder, TestBlockV1Builder, U512,
     };
     use pretty_assertions::assert_eq;
     use rand::Rng;
@@ -431,7 +431,7 @@ mod tests {
         );
         let resp = GetBlock::do_handle_request(
             Arc::new(ValidBlockMock {
-                block: SignedBlock::new(block.clone(), signatures.into()),
+                block: BlockWithSignatures::new(block.clone(), signatures.into()),
                 transfers: vec![],
             }),
             None,
@@ -455,7 +455,7 @@ mod tests {
 
         let resp = GetBlock::do_handle_request(
             Arc::new(ValidBlockMock {
-                block: SignedBlock::new(
+                block: BlockWithSignatures::new(
                     Block::V1(block.clone()),
                     BlockSignaturesV1::new(*block.hash(), block.era_id()).into(),
                 ),
@@ -492,7 +492,7 @@ mod tests {
         );
         let resp = GetBlockTransfers::do_handle_request(
             Arc::new(ValidBlockMock {
-                block: SignedBlock::new(Block::V2(block.clone()), signatures.into()),
+                block: BlockWithSignatures::new(Block::V2(block.clone()), signatures.into()),
                 transfers: transfers.clone(),
             }),
             None,
@@ -523,7 +523,7 @@ mod tests {
         );
         let resp = GetStateRootHash::do_handle_request(
             Arc::new(ValidBlockMock {
-                block: SignedBlock::new(Block::V2(block.clone()), signatures.into()),
+                block: BlockWithSignatures::new(Block::V2(block.clone()), signatures.into()),
                 transfers: vec![],
             }),
             None,
@@ -723,7 +723,7 @@ mod tests {
     }
 
     struct ValidBlockMock {
-        block: SignedBlock,
+        block: BlockWithSignatures,
         transfers: Vec<Transfer>,
     }
 
@@ -736,7 +736,7 @@ mod tests {
             match req {
                 BinaryRequest::Get(GetRequest::Information { info_type_tag, .. })
                     if InformationRequestTag::try_from(info_type_tag)
-                        == Ok(InformationRequestTag::SignedBlock) =>
+                        == Ok(InformationRequestTag::BlockWithSignatures) =>
                 {
                     Ok(BinaryResponseAndRequest::new(
                         BinaryResponse::from_value(self.block.clone(), SUPPORTED_PROTOCOL_VERSION),

--- a/rpc_sidecar/src/rpcs/common.rs
+++ b/rpc_sidecar/src/rpcs/common.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 use crate::rpcs::error::Error;
 use casper_types::{
     bytesrepr::ToBytes, contracts::ContractPackage, global_state::TrieMerkleProof, Account,
-    AddressableEntity, AvailableBlockRange, BlockHeader, BlockIdentifier, ByteCode, Contract,
-    ContractWasm, EntityAddr, EntryPointValue, GlobalStateIdentifier, Key, NamedKeys, Package,
-    BlockWithSignatures, StoredValue,
+    AddressableEntity, AvailableBlockRange, BlockHeader, BlockIdentifier, BlockWithSignatures,
+    ByteCode, Contract, ContractWasm, EntityAddr, EntryPointValue, GlobalStateIdentifier, Key,
+    NamedKeys, Package, StoredValue,
 };
 
 use crate::NodeClient;

--- a/rpc_sidecar/src/rpcs/common.rs
+++ b/rpc_sidecar/src/rpcs/common.rs
@@ -10,7 +10,7 @@ use casper_types::{
     bytesrepr::ToBytes, contracts::ContractPackage, global_state::TrieMerkleProof, Account,
     AddressableEntity, AvailableBlockRange, BlockHeader, BlockIdentifier, ByteCode, Contract,
     ContractWasm, EntityAddr, EntryPointValue, GlobalStateIdentifier, Key, NamedKeys, Package,
-    SignedBlock, StoredValue,
+    BlockWithSignatures, StoredValue,
 };
 
 use crate::NodeClient;
@@ -105,14 +105,14 @@ impl ContractWasmWithProof {
     }
 }
 
-pub async fn get_signed_block(
+pub async fn get_block_with_signatures(
     node_client: &dyn NodeClient,
     identifier: Option<BlockIdentifier>,
-) -> Result<SignedBlock, Error> {
+) -> Result<BlockWithSignatures, Error> {
     match node_client
-        .read_signed_block(identifier)
+        .read_block_with_signatures(identifier)
         .await
-        .map_err(|err| Error::NodeRequest("signed block", err))?
+        .map_err(|err| Error::NodeRequest("block with signatures", err))?
     {
         Some(block) => Ok(block),
         None => {


### PR DESCRIPTION
Resolves #397 by renaming SignedBlock (and similar) to BlockWithSignatures across all of sidecar.