### PR TITLE
Increase the rate of heartbeat checks across default configs

### DIFF
--- a/resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NCTL_CONFIG.toml
@@ -20,7 +20,7 @@ port = 28102
 max_message_size_bytes = 4194304
 message_timeout_secs = 10
 client_access_timeout_secs = 10
-keepalive_timeout_ms = 10_000
+keepalive_timeout_ms = 4_000
 
 [rpc_server.node_client.exponential_backoff]
 initial_delay_ms = 1000

--- a/resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NCTL_POSTGRES_CONFIG.toml
@@ -20,7 +20,7 @@ port = 28102
 max_message_size_bytes = 4194304
 message_timeout_secs = 10
 client_access_timeout_secs = 10
-keepalive_timeout_ms = 10_000
+keepalive_timeout_ms = 4_000
 
 [rpc_server.node_client.exponential_backoff]
 initial_delay_ms = 1000

--- a/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
+++ b/resources/example_configs/EXAMPLE_NODE_CONFIG.toml
@@ -20,7 +20,7 @@ port = 7777
 max_message_size_bytes = 4194304
 message_timeout_secs = 10
 client_access_timeout_secs = 10
-keepalive_timeout_ms = 10_000
+keepalive_timeout_ms = 4_000
 
 [rpc_server.node_client.exponential_backoff]
 initial_delay_ms = 1000

--- a/resources/example_configs/default_debian_config.toml
+++ b/resources/example_configs/default_debian_config.toml
@@ -76,7 +76,7 @@ message_timeout_secs = 10
 # Timeout specifying how long to wait for binary port client to be available.
 client_access_timeout_secs = 10
 # The amount of time in milliseconds to wait between sending keepalive requests.
-keepalive_timeout_ms = 10_000
+keepalive_timeout_ms = 4_000
 
 [rpc_server.node_client.exponential_backoff]
 # The initial delay in milliseconds before the first retry.

--- a/resources/example_configs/default_rpc_only_config.toml
+++ b/resources/example_configs/default_rpc_only_config.toml
@@ -76,7 +76,7 @@ message_timeout_secs = 10
 # Timeout specifying how long to wait for binary port client to be available.
 client_access_timeout_secs = 10
 # The amount of time in milliseconds to wait between sending keepalive requests.
-keepalive_timeout_ms = 10_000
+keepalive_timeout_ms = 4_000
 
 [rpc_server.node_client.exponential_backoff]
 # The initial delay in milliseconds before the first retry.


### PR DESCRIPTION
The default binary port config is such that the node only extends the connection's lifespan by 5 seconds for info requests, but the sidecar will only send a status request every 10 seconds with default configuration.

This PR addresses the issue by increasing the rate at which sidecar will ask for status to once every 4 seconds. Applies to all default configs.

Related PR:
https://github.com/casper-network/casper-node/pull/5097