### PR TITLE
CI publish update

### DIFF
--- a/.github/workflows/publish-casper-event-sidecar-deb.yml
+++ b/.github/workflows/publish-casper-event-sidecar-deb.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
 
 jobs:
   publish_deb:
@@ -25,7 +25,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
-      - uses: Swatinem/rust-cache@cb2cf0cc7c5198d3364b9630e2c3d457f160790c #v1.4.0
         with:
           key: ${{ matrix.code_name }}
 

--- a/.github/workflows/publish-casper-event-sidecar-deb.yml
+++ b/.github/workflows/publish-casper-event-sidecar-deb.yml
@@ -1,5 +1,8 @@
 ---
 name: publish-casper-sidecar-deb
+permissions:
+  contents: read
+  id-token: write
 
 on:
   push:
@@ -13,8 +16,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             code_name: focal
-          - os: ubuntu-22.04
-            code_name: jammy
+#          - os: ubuntu-22.04
+#            code_name: jammy
+#          - os: ubuntu-24.04
+#            code_name: noble
 
     runs-on: ${{ matrix.os }}
 
@@ -24,12 +29,19 @@ jobs:
         with:
           key: ${{ matrix.code_name }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_REPO }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ secrets.AWS_ACCESS_REGION_REPO }}
+
       - name: Install deps
         run: |
           echo "deb http://repo.aptly.info/ squeeze main" | sudo tee -a /etc/apt/sources.list.d/aptly.list
           wget -qO - https://www.aptly.info/pubkey.txt | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get install -y awscli aptly=1.2.0
+          sudo apt-get install -y aptly=1.4.0
           aptly config show
 
       - name: update toolchain
@@ -45,35 +57,20 @@ jobs:
         run: cargo install cargo-deb
 
       - name: Cargo deb
-        run: cargo deb --no-build --variant ${{ matrix.code_name }}
+        run: cargo deb --package casper-sidecar --variant ${{ matrix.code_name }}
 
       - name: Upload binaries to repo
         env:
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.APTLY_SECRET_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.APTLY_ACCESS_KEY }}
-          PLUGIN_REPO_NAME: ${{ secrets.APTLY_REPO }}
-          PLUGIN_REGION: ${{ secrets.APTLY_REGION }}
+          PLUGIN_REPO_NAME: ${{ secrets.AWS_BUCKET_REPO }}
+          PLUGIN_REGION: ${{ secrets.AWS_ACCESS_REGION_REPO }}
           PLUGIN_GPG_KEY: ${{ secrets.APTLY_GPG_KEY }}
           PLUGIN_GPG_PASS: ${{ secrets.APTLY_GPG_PASS }}
-          PLUGIN_ACL: 'public-read'
+          PLUGIN_ACL: 'private'
           PLUGIN_PREFIX: 'releases'
           PLUGIN_DEB_PATH: './target/debian'
           PLUGIN_OS_CODENAME: ${{ matrix.code_name }}
         run: ./ci/publish_deb_to_repo.sh
 
-      - name: Invalidate cloudfront
-        uses: chetan/invalidate-cloudfront-action@c384d5f09592318a77b1e5c0c8d4772317e48b25 #v2.4
-        env:
-          DISTRIBUTION: ${{ secrets.APTLY_DIST_ID }}
-          PATHS: "/*"
-          AWS_REGION: ${{ secrets.APTLY_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.APTLY_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.APTLY_SECRET_KEY }}
-
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@133984371c30d34e38222a64855679a414cb7575 #v2.3.0
-        with:
-          repo_token: ${{ secrets.TOKEN_FOR_GITHUB }}
-          file: target/debian/casper-sidecar/*
-          tag: ${{ github.ref }}
-          file_glob: true
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_REPO }} --paths "/*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "casper-sidecar"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/ci/publish_deb_to_repo.sh
+++ b/ci/publish_deb_to_repo.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-# DEFAULTS
-#PLUGIN_OS_CODENAME="${PLUGIN_OS_CODENAME:-bionic}"
-
 # Verify all variables are present
 if [[ -z $PLUGIN_GPG_KEY || -z $PLUGIN_GPG_PASS || -z $PLUGIN_REGION \
         || -z $PLUGIN_REPO_NAME || -z $PLUGIN_ACL || -z $PLUGIN_PREFIX \
-#        || -z $AWS_SECRET_ACCESS_KEY || -z $AWS_ACCESS_KEY_ID \
         || -z $PLUGIN_DEB_PATH || -z $PLUGIN_OS_CODENAME ]]; then
     echo "ERROR: Environment Variable Missing!"
     exit 1

--- a/ci/publish_deb_to_repo.sh
+++ b/ci/publish_deb_to_repo.sh
@@ -2,12 +2,12 @@
 set -e
 
 # DEFAULTS
-PLUGIN_OS_CODENAME="${PLUGIN_OS_CODENAME:-bionic}"
+#PLUGIN_OS_CODENAME="${PLUGIN_OS_CODENAME:-bionic}"
 
 # Verify all variables are present
 if [[ -z $PLUGIN_GPG_KEY || -z $PLUGIN_GPG_PASS || -z $PLUGIN_REGION \
         || -z $PLUGIN_REPO_NAME || -z $PLUGIN_ACL || -z $PLUGIN_PREFIX \
-        || -z $AWS_SECRET_ACCESS_KEY || -z $AWS_ACCESS_KEY_ID \
+#        || -z $AWS_SECRET_ACCESS_KEY || -z $AWS_ACCESS_KEY_ID \
         || -z $PLUGIN_DEB_PATH || -z $PLUGIN_OS_CODENAME ]]; then
     echo "ERROR: Environment Variable Missing!"
     exit 1

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -59,3 +59,7 @@ revision = "0+bionic"
 [package.metadata.deb.variants.focal]
 name = "casper-sidecar"
 revision = "0+focal"
+
+[package.metadata.deb.variants.jammy]
+name = "casper-sidecar"
+revision = "0+jammy"

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-sidecar"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Jakub Zajkowski <jakub@casperlabs.io>"]
 edition = "2021"
 description = "Base module that spins up casper sidecar"


### PR DESCRIPTION
Update CI for tag v* based publish of debian package to repo.casper.network.

In testing 1.0.0 was published, and casper-sidecar was bumped to 1.0.1 version with this PR to allow a tag based publish of v1.0.1