### PR TITLE
Corrections for audit CI failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "casper-event-types",
  "casper-types",
  "colored 2.2.0",
+ "deranged",
  "derive-new",
  "eventsource-stream",
  "futures",
@@ -981,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -4251,9 +4252,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/event_sidecar/Cargo.toml
+++ b/event_sidecar/Cargo.toml
@@ -27,6 +27,7 @@ bytes = "1.2.0"
 casper-event-listener = { workspace = true }
 casper-event-types = { workspace = true }
 casper-types = { workspace = true }
+deranged = "=0.4.0"
 derive-new = { workspace = true }
 eventsource-stream = "0.2.3"
 futures = { workspace = true }


### PR DESCRIPTION
Pinning deranged to 0.40.0 for yanked crate fix
Updated tokio to 1.44.2 for audit fix.